### PR TITLE
fix: 진도향토문화회관 cctvip 불일치 수정 (73606→73604)

### DIFF
--- a/cctv_data.json
+++ b/cctv_data.json
@@ -87011,7 +87011,7 @@
     "name": "[국도18호선]진도향토문화회관",
     "source": "UTIC",
     "status": "active",
-    "url": "https://www.utic.go.kr/jsp/map/openDataCctvStream.jsp?key=yjEgVGKAyWZGHyTy0gqNA8ZAq6IudLYWVqk8frqUI&cctvid=E901115&cctvName=%5B%EA%B5%AD%EB%8F%8418%ED%98%B8%EC%84%A0%5D%EC%A7%84%EB%8F%84%ED%96%A5%ED%86%A0%EB%AC%B8%ED%99%94%ED%9A%8C%EA%B4%80&kind=Z3&cctvip=73606&id=73606%2F3evlqJ938Y1mHSqTP8wWQXfE2%2F6iwv8KTEPdZoToC2r7iYWfJNvB8uNZ6%2F9Rsw5K%2BFwN08nviC1xuiMFjORAeGHwYXprRCXvXb3KUPFMwT0%3D"
+    "url": "https://www.utic.go.kr/jsp/map/openDataCctvStream.jsp?key=yjEgVGKAyWZGHyTy0gqNA8ZAq6IudLYWVqk8frqUI&cctvid=E901115&cctvName=%5B%EA%B5%AD%EB%8F%8418%ED%98%B8%EC%84%A0%5D%EC%A7%84%EB%8F%84%ED%96%A5%ED%86%A0%EB%AC%B8%ED%99%94%ED%9A%8C%EA%B4%80&kind=Z3&cctvip=73604&id=73604%2FTZyaRqBZxHm3rPvMBbYDvZBh6cTnxbHhhd80NOpNxhdkZwgaHpZAUkj%2FA8xLkDTw"
   },
   {
     "backup_urls": [],

--- a/cctv_overrides.json
+++ b/cctv_overrides.json
@@ -240,7 +240,7 @@
   {
     "id": "E901115",
     "name": "[국도18호선]진도향토문화회관",
-    "url": "https://www.utic.go.kr/jsp/map/openDataCctvStream.jsp?key=yjEgVGKAyWZGHyTy0gqNA8ZAq6IudLYWVqk8frqUI&cctvid=E901115&cctvName=%5B%EA%B5%AD%EB%8F%8418%ED%98%B8%EC%84%A0%5D%EC%A7%84%EB%8F%84%ED%96%A5%ED%86%A0%EB%AC%B8%ED%99%94%ED%9A%8C%EA%B4%80&kind=Z3&cctvip=73606&id=73606%2F3evlqJ938Y1mHSqTP8wWQXfE2%2F6iwv8KTEPdZoToC2r7iYWfJNvB8uNZ6%2F9Rsw5K%2BFwN08nviC1xuiMFjORAeGHwYXprRCXvXb3KUPFMwT0%3D",
+    "url": "https://www.utic.go.kr/jsp/map/openDataCctvStream.jsp?key=yjEgVGKAyWZGHyTy0gqNA8ZAq6IudLYWVqk8frqUI&cctvid=E901115&cctvName=%5B%EA%B5%AD%EB%8F%8418%ED%98%B8%EC%84%A0%5D%EC%A7%84%EB%8F%84%ED%96%A5%ED%86%A0%EB%AC%B8%ED%99%94%ED%9A%8C%EA%B4%80&kind=Z3&cctvip=73604&id=73604%2FTZyaRqBZxHm3rPvMBbYDvZBh6cTnxbHhhd80NOpNxhdkZwgaHpZAUkj%2FA8xLkDTw",
     "tags": [],
     "_comment": "Auto-extracted from VIP logic"
   },


### PR DESCRIPTION
## Summary
- 진도향토문화회관(E901115)의 cctvip가 UTIC(73606)과 ITS(73604)에서 불일치
- z3_cache.json은 ITS 기반이므로 cctvip=73606으로 조회하면 잘못된 카메라 토큰을 받아 영상이 안 나옴
- cctvip를 73604로 수정하여 ITS 데이터와 일치시킴

## Test plan
- [ ] 진도향토문화회관 CCTV 영상이 정상 재생되는지 확인

https://claude.ai/code/session_0162SrFSoC2azT2tqD6wSwn3