### PR TITLE
feat(world-tour): chip rail drag/scroll fix, mobile favorite icon, sticky list toggle, raised bottom menu, English map labels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1998,6 +1998,7 @@ body.world-tour-active #pwa-install-prompt {
     align-items: center;
     gap: 8px;
     min-width: 0;
+    position: relative;
 }
 
 .world-tour-region-tabs {
@@ -2005,20 +2006,28 @@ body.world-tour-active #pwa-install-prompt {
     gap: 8px;
     padding: 0 8px;
     overflow-x: auto;
+    overflow-y: hidden;
     cursor: grab;
     touch-action: pan-x;
     user-select: none;
     scrollbar-width: none;
+    /* WebKit thin scrollbar so the drag affordance is visible on hover. */
+    scroll-behavior: smooth;
 }
 
+/* When inside the persistent bottom bar, the chip rail must actually shrink
+ * to its parent so overflow scroll triggers and the list toggle stays put. */
 .world-tour-bottom-menu .world-tour-region-tabs {
-    flex: 1 1 auto;
-    flex-shrink: 0;
+    flex: 1 1 0;
+    min-width: 0;
     padding: 0;
+    -webkit-mask-image: linear-gradient(90deg, transparent 0, #000 12px, #000 calc(100% - 16px), transparent 100%);
+    mask-image: linear-gradient(90deg, transparent 0, #000 12px, #000 calc(100% - 16px), transparent 100%);
 }
 
 .world-tour-region-tabs::-webkit-scrollbar {
     display: none;
+    height: 0;
 }
 
 .world-tour-region-tab {
@@ -2855,11 +2864,31 @@ body.world-tour-active #pwa-install-prompt {
         gap: 10px;
         height: var(--world-tour-menu-height);
         max-height: none;
-        padding: 10px 10px calc(10px + env(safe-area-inset-bottom));
+        /* Lift the bottom menu so the last row isn't clipped behind the
+         * iOS home indicator / Android nav bar. */
+        padding: 10px 10px calc(18px + env(safe-area-inset-bottom));
         border-right: 0;
         border-bottom: 0;
         border-left: 0;
         border-radius: 0;
+    }
+
+    /* On narrow screens the "Favorite" word eats space — keep only star + count. */
+    .world-tour-region-tab[data-world-region="Favorite"] .world-tour-region-tab-label > span:not(.world-tour-favorite-tab-icon) {
+        display: none;
+    }
+    .world-tour-region-tab[data-world-region="Favorite"] {
+        padding: 0 10px;
+    }
+
+    /* Pin the list toggle to the right edge of the chip row so it is
+     * always reachable, even when many region chips are scrolled. The chip
+     * rail uses flex:1 1 0 so the toggle naturally anchors to the right. */
+    .world-tour-region-bar .world-tour-list-toggle {
+        margin-left: 6px;
+        box-shadow: -12px 0 18px -8px rgba(2, 6, 23, 0.85);
+        z-index: 2;
+        flex: 0 0 38px;
     }
 
     .world-tour-selected-summary {
@@ -3099,7 +3128,7 @@ body.world-tour-active #pwa-install-prompt {
 
     .world-tour-bottom-menu {
         gap: 8px;
-        padding: 8px 8px calc(8px + env(safe-area-inset-bottom));
+        padding: 8px 8px calc(16px + env(safe-area-inset-bottom));
     }
 
     .world-tour-selected-summary {

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <link rel="dns-prefetch" href="//dapi.kakao.com">
     <link rel="dns-prefetch" href="//tile.openstreetmap.org">
-    <link rel="stylesheet" href="css/style.css?v=20260521-ui-refresh1">
+    <link rel="stylesheet" href="css/style.css?v=20260521-ui-refresh2">
 
     <!-- Kakao Maps -->
     <script type="text/javascript"
@@ -253,7 +253,7 @@
             summaryUrl: 'https://cctv-quality.pyw31337.workers.dev/v1/summary'
         };
     </script>
-    <script src="js/app.js?v=20260521-ui-refresh1"></script>
+    <script src="js/app.js?v=20260521-ui-refresh2"></script>
 </body>
 
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -14,7 +14,7 @@ const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-ui-refresh1';
+const APP_BUILD_VERSION = '20260521-ui-refresh2';
 const SERVICE_BANNER_VISIBLE_MS = 5000;
 const PLAYBACK_HEALTH_STORAGE_KEY = 'cctv_playback_health_v1';
 const PLAYBACK_HEALTH_SCHEMA_VERSION = 2;
@@ -5657,6 +5657,21 @@ function enableHorizontalDragScroll(scroller, onScroll) {
         event.preventDefault();
         event.stopImmediatePropagation();
     }, true);
+
+    // Convert vertical mouse-wheel scroll into horizontal scroll so users on
+    // a standard wheel mouse (without a trackpad) can also browse the chips.
+    scroller.addEventListener('wheel', event => {
+        if (event.deltaY === 0 || Math.abs(event.deltaX) > Math.abs(event.deltaY)) return;
+        const maxScroll = scroller.scrollWidth - scroller.clientWidth;
+        if (maxScroll <= 0) return;
+        const current = scroller.scrollLeft;
+        // Stop scroll bleed-through to the page only when we'll actually move.
+        const headroom = event.deltaY > 0 ? maxScroll - current : current;
+        if (headroom <= 0) return;
+        event.preventDefault();
+        scroller.scrollLeft = current + event.deltaY;
+        onScroll?.(scroller.scrollLeft);
+    }, { passive: false });
 }
 
 function cleanupWorldTourVideoPlayers(root = document) {
@@ -6086,9 +6101,14 @@ async function initWorldTourMap(selected, visibleCams) {
 
         L.control.zoom({ position: 'topright' }).addTo(worldTourLeafletMap);
 
-        L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            maxZoom: 18,
-            attribution: '&copy; OpenStreetMap contributors'
+        // Tile choice: CartoDB Voyager — uses Latin (English) place names
+        // worldwide, which is much more readable than OSM Standard (where
+        // labels in CJK / Cyrillic / Arabic regions appear in the local script).
+        // {r} adds @2x for HiDPI screens automatically.
+        L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
+            maxZoom: 19,
+            subdomains: 'abcd',
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attributions">CARTO</a>'
         }).addTo(worldTourLeafletMap);
 
         const mappableCams = visibleCams


### PR DESCRIPTION
## PR1.5: Chip bar + map polish

### Findings (사용자 보고)
1. 지역 칩 row가 드래그되지 않음 — **원인**: `.world-tour-bottom-menu .world-tour-region-tabs`에 `flex-shrink: 0`이 걸려있어 부모 폭을 무시하고 콘텐츠 폭 그대로 늘어남 → 내부 `overflow-x: auto`가 절대 트리거되지 않고 컨테이너만 잘림.
2. 모바일에서 `(별) Favorite 0` 너비가 큼
3. 리스트 메뉴(우상단 아이콘)가 우측에 고정되어 있지 않아 칩 row가 길어지면 같이 밀려나감
4. 모바일 하단 메뉴 마지막 줄이 safe-area / 홈 인디케이터에 잘림
5. Leaflet 지도 라벨이 한자/현지 문자

### Changes
- **chip rail**: `flex: 1 1 0` + `min-width: 0`으로 변경해 부모에 fit되고 내부 가로 스크롤이 실제로 동작. wheel 이벤트 → horizontal scroll 변환 핸들러 추가 (트랙패드 없이도 마우스 휠로 칩 탐색). 양 끝 페이드 mask로 스크롤 가능 표시.
- **mobile**: `[data-world-region="Favorite"]` 칩 내부 텍스트 span을 `display: none`. 별 + 카운트만 잔류.
- **list toggle**: region-bar의 마지막 sibling으로 자연스럽게 우측 끝 고정 (`flex: 0 0 38px`, 좌측 box-shadow 분리선).
- **bottom menu lift**: padding-bottom을 `calc(10px + safe-area)`에서 `calc(18px + safe-area)`로 (399px breakpoint에서는 16px) — iOS/안드로이드 하단 인디케이터 위로 살짝 올림.
- **Leaflet tiles**: OSM Standard → **CartoDB Voyager** (`{s}.basemaps.cartocdn.com/rastertiles/voyager/...`). 전 세계 라벨이 Latin 표기로 통일되어 가독성 향상. retina `{r}` 자동.
- 빌드 버전 `20260521-ui-refresh2`로 bump.

### 통계 (요청 별도 답변): 
- 1,515개 World Tour 카메라 중 **940개 (62.0%)**가 `이 영상은 원본 사이트에서 안정적으로 재생됩니다.` 표시 대상 (인앱 임베드 불가, 원본 링크 only). Europe 416 / North America 257 / Asia 147 / South America 75 / Oceania 31 / Africa 14.
- 상위 5개 소스: WorldCam 97, Baltic Live Cam 96, HK Transport 70, Clima Ao Vivo 69, EarthCam 58.