### PR TITLE
feat(world-tour): in-app snapshot playback for 181 external-only cams (PR1.6)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3657,3 +3657,57 @@ body.world-tour-active #pwa-install-prompt {
     text-transform: uppercase;
     letter-spacing: 0.03em;
 }
+
+/* === World Tour snapshot hero (HK/USGS/Panomax/Roundshot direct JPG) === */
+.world-tour-snapshot-hero {
+    position: relative;
+    overflow: hidden;
+    background: #000;
+}
+
+.world-tour-snapshot-img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    object-position: center;
+    background: #000;
+}
+
+.world-tour-snapshot-overlay {
+    position: absolute;
+    left: 12px;
+    bottom: 12px;
+    display: inline-flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 8px 12px;
+    background: rgba(2, 6, 23, 0.72);
+    backdrop-filter: blur(10px);
+    border-radius: 999px;
+    color: var(--text-primary);
+    font-size: 11px;
+    line-height: 1.2;
+    pointer-events: none;
+}
+
+.world-tour-snapshot-badge {
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    color: #bbf7d0;
+}
+
+.world-tour-snapshot-meta {
+    font-size: 10px;
+    color: var(--text-secondary);
+}
+
+@media (max-width: 600px) {
+    .world-tour-snapshot-overlay {
+        left: 8px;
+        bottom: 8px;
+        padding: 6px 10px;
+        border-radius: 14px;
+        font-size: 10px;
+    }
+}

--- a/data/world_tour_cams.json
+++ b/data/world_tour_cams.json
@@ -15868,7 +15868,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/6985febf903e98.41120783/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1273",
@@ -15897,7 +15899,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/5df0edf6b4e0b3.73492331/2026-05-21/03-00-00/2026-05-21-03-00-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1913",
@@ -15926,7 +15930,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/6405a3bd31e815.69114684/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1592",
@@ -15955,7 +15961,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/60ca12e262eb55.14623960/2026-05-21/03-00-00/2026-05-21-03-00-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1591",
@@ -15984,7 +15992,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/60ca10d050e1c6.36523180/2026-05-20/21-10-00/2026-05-20-21-10-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-162",
@@ -16013,7 +16023,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/53ce6a088e0b28.00564708/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-2482",
@@ -16042,7 +16054,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/67e176d1402135.40832450/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1250",
@@ -16071,7 +16085,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5dd571e14c8d10.06684428/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-875",
@@ -16100,7 +16116,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/5ab8ba577a66e4.87843214/2026-05-21/02-50-00/2026-05-21-02-50-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1255",
@@ -16129,7 +16147,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5dd575d88ff6f4.69086930/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1251",
@@ -16158,7 +16178,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5dd57245813f98.01911817/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1258",
@@ -16187,7 +16209,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5dd5768f8f3e19.24925088/2026-05-20/21-00-00/2026-05-20-21-00-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-87",
@@ -16216,7 +16240,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/53aacd05e65407.10715840/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-892",
@@ -16245,7 +16271,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/5aec2275b5dad4.34391000/2026-05-21/03-00-00/2026-05-21-03-00-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-886",
@@ -16274,7 +16302,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/5aeb76197538d3.39429739/2026-05-21/03-00-00/2026-05-21-03-00-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1013",
@@ -16303,7 +16333,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5bbfa31cd4b510.45617515/2026-05-21/03-00-00/2026-05-21-03-00-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1318",
@@ -16332,7 +16364,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/5e568a0aaea5b0.54147912/2026-05-21/03-00-00/2026-05-21-03-00-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1912",
@@ -16361,7 +16395,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/64059bf5186439.31729937/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-58",
@@ -16390,7 +16426,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/53aa922da49ec7.57439399/2026-05-21/02-50-00/2026-05-21-02-50-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-2194",
@@ -16419,7 +16457,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/66deccab16e958.41861775/2026-05-20/21-11-00/2026-05-20-21-11-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1136",
@@ -16448,7 +16488,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5cda5bf21a7198.55013080/2026-05-21/00-40-00/2026-05-21-00-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1965",
@@ -16477,7 +16519,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/649983360bb346.52171651/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1268",
@@ -16506,7 +16550,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/5dea20fe356da5.66127651/2026-05-20/21-10-00/2026-05-20-21-10-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1246",
@@ -16535,7 +16581,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5dcc1e9e030070.06377080/2026-01-07/19-00-00/2026-01-07-19-00-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1256",
@@ -16564,7 +16612,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5dd5762379f403.02309480/2026-05-21/02-30-00/2026-05-21-02-30-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1253",
@@ -16593,7 +16643,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5dd572ed217448.13831429/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-2660",
@@ -16622,7 +16674,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/6985fbe4a66ae0.39376263/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-908",
@@ -16651,7 +16705,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5b07b425c33048.76749639/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-95",
@@ -16680,7 +16736,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/53aad7f638ecd6.53792695/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1257",
@@ -16709,7 +16767,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5dd5765bd47316.88564927/2026-05-21/02-50-00/2026-05-21-02-50-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-2158",
@@ -16738,7 +16798,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/60e2d724904465.41029159/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1252",
@@ -16767,7 +16829,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5dd57285747da0.74612870/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1259",
@@ -16796,7 +16860,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5dd576eb8ffae5.67357181/2026-05-20/21-00-00/2026-05-20-21-00-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1531",
@@ -16825,7 +16891,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/602d39041390e6.94878911/2026-05-20/20-50-00/2026-05-20-20-50-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-295",
@@ -16854,7 +16922,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage2.roundshot.com/54bd09aee73172.33986649/2026-05-21/02-40-00/2026-05-21-02-40-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-1254",
@@ -16883,7 +16953,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/5dd57433a13c58.72193378/2026-05-20/22-00-00/2026-05-20-22-00-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "roundshot-94",
@@ -16912,7 +16984,9 @@
       "sourceOnly": true,
       "stabilityScore": 80,
       "qualityScore": 80,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://storage.roundshot.com/53aad6578ec082.95526880/2026-05-21/02-30-00/2026-05-21-02-30-00_centerprev.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "webcamera24-staugustine-matanzas-river-cam",
@@ -18552,7 +18626,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/879/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-23",
@@ -18636,7 +18712,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1256/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1658",
@@ -18664,7 +18742,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1222/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1713",
@@ -18692,7 +18772,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1271/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-701",
@@ -18720,7 +18802,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/519/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1203",
@@ -18748,7 +18832,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/867/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1774",
@@ -18776,7 +18862,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1319/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1512",
@@ -18804,7 +18892,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1105/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1856",
@@ -18832,7 +18922,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1386/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-17",
@@ -18888,7 +18980,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1438/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1599",
@@ -18916,7 +19010,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1170/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-16",
@@ -18972,7 +19068,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/193/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-7",
@@ -19112,7 +19210,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1097/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-573",
@@ -19140,7 +19240,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/426/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1643",
@@ -19168,7 +19270,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1209/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1270",
@@ -19196,7 +19300,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/916/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-101",
@@ -19252,7 +19358,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/619/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1369",
@@ -19280,7 +19388,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1007/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-2085",
@@ -19308,7 +19418,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1555/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1831",
@@ -19336,7 +19448,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1365/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1465",
@@ -19364,7 +19478,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1090/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1289",
@@ -19392,7 +19508,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/931/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-26",
@@ -19420,7 +19538,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/26/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1285",
@@ -19448,7 +19568,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/927/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1349",
@@ -19476,7 +19598,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/987/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1798",
@@ -19504,7 +19628,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1342/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1316",
@@ -19532,7 +19658,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/958/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-2101",
@@ -19560,7 +19688,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1569/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1511",
@@ -19588,7 +19718,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1104/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "panomax-1647",
@@ -19616,7 +19748,9 @@
       "sourceOnly": true,
       "stabilityScore": 77,
       "qualityScore": 77,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://panodata.panomax.com/cams/1213/preview_og.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "livebeaches-webcams-maui-sea-shell-condo-beach-cam",
@@ -22623,7 +22757,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/akunIsland-SE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-akunisland-n",
@@ -22651,7 +22787,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/akunIsland-N/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-akunisland-w",
@@ -22679,7 +22817,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/akunIsland-W/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-akutan-aksd",
@@ -22707,7 +22847,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/akutan_aksd/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-akutan-av06",
@@ -22735,7 +22877,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/akutan_av06/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-anchorpoint-n",
@@ -22763,7 +22907,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/anchorPoint-N/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-anchorpoint-ne",
@@ -22791,7 +22937,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/anchorPoint-NE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-anchorpoint-se",
@@ -22819,7 +22967,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/anchorPoint-SE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-anchorage-e",
@@ -22847,7 +22997,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/anchorage-E/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-anchorage-s",
@@ -22875,7 +23027,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/anchorage-S/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-aniakchak-ansl",
@@ -22903,7 +23057,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/aniakchak_ansl/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-aniakchak-pth",
@@ -22931,7 +23087,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/aniakchak_pth/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-aug-lagoon",
@@ -22959,7 +23117,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/aug_lagoon/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-aug-mound",
@@ -22987,7 +23147,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/aug_mound/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-augustine",
@@ -23015,7 +23177,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/augustine/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-beluga-ne",
@@ -23043,7 +23207,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/beluga-NE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-beluga-nw",
@@ -23071,7 +23237,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/beluga-NW/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-beluga-se",
@@ -23099,7 +23267,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/beluga-SE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chignikbay-ne",
@@ -23127,7 +23297,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chignikBay-NE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chignikbay-nw",
@@ -23155,7 +23327,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chignikBay-NW/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chignikbay-se",
@@ -23183,7 +23357,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chignikBay-SE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chignikbay-sw",
@@ -23211,7 +23387,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chignikBay-SW/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chigniklagoon-ne",
@@ -23239,7 +23417,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chignikLagoon-NE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chigniklagoon-sw",
@@ -23267,7 +23447,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chignikLagoon-SW/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chigniklake-e",
@@ -23295,7 +23477,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chignikLake-E/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chigniklake-ne",
@@ -23323,7 +23507,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chignikLake-NE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chigniklake-nw",
@@ -23351,7 +23537,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chignikLake-NW/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chigniklake-s",
@@ -23379,7 +23567,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chignikLake-S/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chistochina-e",
@@ -23407,7 +23597,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chistochina-E/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chistochina-ne",
@@ -23435,7 +23627,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chistochina-NE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chistochina-sw",
@@ -23463,7 +23657,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chistochina-SW/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chitina-n",
@@ -23491,7 +23687,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chitina-N/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chitina-s",
@@ -23519,7 +23717,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chitina-S/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chitina-se",
@@ -23547,7 +23747,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chitina-SE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-cleveland-clcl",
@@ -23575,7 +23777,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/cleveland_clcl/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-anchorpoint-w",
@@ -23603,7 +23807,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/anchorPoint-W/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-shasta-snowcrest",
@@ -23659,7 +23865,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/anchorage-SW/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-beluga-sw",
@@ -23687,7 +23895,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/beluga-SW/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-amchitka-aht",
@@ -23715,7 +23925,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/amchitka_aht/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-anchorage-nw",
@@ -23743,7 +23955,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/anchorage-NW/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chistochina-se",
@@ -23771,7 +23985,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chistochina-SE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chitina-ne",
@@ -23799,7 +24015,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chitina-NE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-ys-bbsn",
@@ -23827,7 +24045,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/ys-bbsn/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "usgsvolcano-chigniklagoon-se",
@@ -23855,7 +24075,9 @@
       "sourceOnly": true,
       "stabilityScore": 73,
       "qualityScore": 73,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://volcview.wr.usgs.gov/ashcam-api/images/webcams/chignikLagoon-SE/current.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "webcamtaxi-london-heathrow",
@@ -28650,7 +28872,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H422F2.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h216f",
@@ -28678,7 +28902,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H216F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k104f",
@@ -28706,7 +28932,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K104F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-tw117f",
@@ -28734,7 +28962,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/TW117F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-tw109f",
@@ -28762,7 +28992,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/TW109F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-tc101f",
@@ -28790,7 +29022,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/TC101F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h106f",
@@ -28818,7 +29052,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H106F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h138f",
@@ -28846,7 +29082,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H138F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h207f",
@@ -28874,7 +29112,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H207F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k107f",
@@ -28902,7 +29142,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K107F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h204f",
@@ -28930,7 +29172,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H204F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h803f",
@@ -28958,7 +29202,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H803F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k404f",
@@ -28986,7 +29232,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K404F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-tw105f",
@@ -29014,7 +29262,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/TW105F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k812f",
@@ -29042,7 +29292,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K812F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k405f",
@@ -29070,7 +29322,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K405F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k506f",
@@ -29098,7 +29352,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K506F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k409f",
@@ -29126,7 +29382,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K409F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k408f",
@@ -29154,7 +29412,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K408F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k502f",
@@ -29182,7 +29442,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K502F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "viewsurf-univers-ville-vue-5379-france-aquitaine-bayonne-place-paul-bert",
@@ -37052,7 +37314,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H429F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h421f",
@@ -37080,7 +37344,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H421F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h210f",
@@ -37108,7 +37374,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H210F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k202f",
@@ -37136,7 +37404,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K202F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k209f",
@@ -37164,7 +37434,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K209F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h904f",
@@ -37192,7 +37464,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H904F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h305f",
@@ -37220,7 +37494,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H305F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k106f",
@@ -37248,7 +37524,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K106F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k109f",
@@ -37276,7 +37554,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K109F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k221f",
@@ -37304,7 +37584,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K221F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-sm936f",
@@ -37332,7 +37614,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/SM936F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k305f",
@@ -37360,7 +37644,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K305F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-tc302f",
@@ -37388,7 +37674,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/TC302F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k802f",
@@ -37416,7 +37704,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K802F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-tk110f",
@@ -37444,7 +37734,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/TK110F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k627f",
@@ -37472,7 +37764,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K627F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h110f",
@@ -37500,7 +37794,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H110F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h222f",
@@ -37528,7 +37824,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H222F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h215f",
@@ -37556,7 +37854,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H215F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h802f",
@@ -37584,7 +37884,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H802F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h801f",
@@ -37612,7 +37914,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H801F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k108f",
@@ -37640,7 +37944,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K108F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k613f",
@@ -37668,7 +37974,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K613F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h307f",
@@ -37696,7 +38004,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H307F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-tw102f",
@@ -37724,7 +38034,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/TW102F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-tw108f",
@@ -37752,7 +38064,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/TW108F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k325f",
@@ -37780,7 +38094,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K325F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k814f",
@@ -37808,7 +38124,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K814F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k813f",
@@ -37836,7 +38154,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K813F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k809f2",
@@ -37864,7 +38184,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K809F2.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k621f",
@@ -37892,7 +38214,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K621F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k810f",
@@ -37920,7 +38244,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K810F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k804f",
@@ -37948,7 +38274,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K804F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k505f",
@@ -37976,7 +38304,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K505F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k508f",
@@ -38004,7 +38334,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K508F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h107f",
@@ -38032,7 +38364,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H107F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-tk101f",
@@ -38060,7 +38394,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/TK101F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-tk105f",
@@ -38088,7 +38424,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/TK105F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h130f",
@@ -38116,7 +38454,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H130F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h132f2",
@@ -38144,7 +38484,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H132F2.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k521f",
@@ -38172,7 +38514,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K521F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h109f",
@@ -38200,7 +38544,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H109F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h108f",
@@ -38228,7 +38574,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H108F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-tw116f",
@@ -38256,7 +38604,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/TW116F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-tk904f",
@@ -38284,7 +38634,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/TK904F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-tc104f",
@@ -38312,7 +38664,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/TC104F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k816f",
@@ -38340,7 +38694,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K816F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-k914f",
@@ -38368,7 +38724,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/K914F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h422f1",
@@ -38396,7 +38754,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H422F1.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "hktraffic-h401f",
@@ -38424,7 +38784,9 @@
       "sourceOnly": true,
       "stabilityScore": 66,
       "qualityScore": 66,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://tdcctv.data.one.gov.hk/H401F.JPG",
+      "playbackKind": "snapshot"
     },
     {
       "id": "publictraffic-virginia-hrbt",
@@ -41731,5 +42093,14 @@
     "openWebcamDbStatus": "API-key gated via OPENWEBCAMDB_API_KEY; default disabled until terms and attribution are configured.",
     "insecamStatus": "Excluded: unsecured private surveillance camera directory, not suitable for this curated public tourist dataset.",
     "africamLimit": 18
+  },
+  "snapshotEnrichmentMeta": {
+    "counts": {
+      "roundshot": 37,
+      "usgsvolcano": 44,
+      "hktraffic": 70,
+      "panomax": 30
+    },
+    "total": 181
   }
 }

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <link rel="dns-prefetch" href="//dapi.kakao.com">
     <link rel="dns-prefetch" href="//tile.openstreetmap.org">
-    <link rel="stylesheet" href="css/style.css?v=20260521-ui-refresh2">
+    <link rel="stylesheet" href="css/style.css?v=20260521-snapshot-playback">
 
     <!-- Kakao Maps -->
     <script type="text/javascript"
@@ -253,7 +253,7 @@
             summaryUrl: 'https://cctv-quality.pyw31337.workers.dev/v1/summary'
         };
     </script>
-    <script src="js/app.js?v=20260521-ui-refresh2"></script>
+    <script src="js/app.js?v=20260521-snapshot-playback"></script>
 </body>
 
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -14,7 +14,7 @@ const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-ui-refresh2';
+const APP_BUILD_VERSION = '20260521-snapshot-playback';
 const SERVICE_BANNER_VISIBLE_MS = 5000;
 const PLAYBACK_HEALTH_STORAGE_KEY = 'cctv_playback_health_v1';
 const PLAYBACK_HEALTH_SCHEMA_VERSION = 2;
@@ -4939,7 +4939,21 @@ function renderWorldTourHashTags(cam) {
 }
 
 function canPlayWorldTourInApp(cam) {
-    return Boolean(cam?.videoId || cam?.embedUrl || cam?.playUrl);
+    // A cam is "playable in-app" if we can render *any* live representation
+    // inside our page — either a video/iframe player or an auto-refreshing
+    // snapshot image (HK Traffic / USGS / Panomax / Roundshot).
+    return Boolean(cam?.videoId || cam?.embedUrl || cam?.playUrl || cam?.snapshotUrl);
+}
+
+// Returns a suggested refresh cadence (ms) for snapshot-based cameras.
+// Conservative defaults keep CDN load reasonable while feeling "live".
+function getWorldTourSnapshotRefreshMs(cam) {
+    const sourceType = (cam?.sourceType || '').toLowerCase();
+    if (sourceType === 'hktraffic') return 30_000;     // HK CCTV: 30s
+    if (sourceType === 'usgsvolcano') return 60_000;   // USGS volc: 1min
+    if (sourceType === 'panomax') return 5 * 60_000;   // Panomax: 5min
+    if (sourceType === 'roundshot') return 0;          // Roundshot URL is dated; no refresh
+    return 60_000;
 }
 
 function isWorldTourHlsUrl(url) {
@@ -5524,43 +5538,94 @@ function renderWorldTourVideoHero(selected) {
     const embedUrl = getWorldTourEmbedUrl(selected);
     const sourceLabel = getWorldTourSourceLabel(selected);
     const isDirectVideo = isWorldTourHlsUrl(embedUrl) || isWorldTourDirectVideoUrl(embedUrl);
+    const snapshotUrl = !embedUrl ? (selected.snapshotUrl || '') : '';
 
-    return `
-        <section class="world-tour-hero">
-            ${embedUrl && isDirectVideo ? `
-                <div class="world-tour-video">
-                    <video
-                        class="world-tour-direct-video"
-                        data-world-tour-stream="${escapeWorldTourHtml(embedUrl)}"
-                        data-world-tour-title="${escapeWorldTourHtml(selected.title)}"
-                        autoplay
-                        muted
-                        playsinline
-                        controls
-                    ></video>
-                    <div class="world-tour-video-loading">영상을 불러오는 중...</div>
+    let mediaHtml;
+    if (embedUrl && isDirectVideo) {
+        mediaHtml = `
+            <div class="world-tour-video">
+                <video
+                    class="world-tour-direct-video"
+                    data-world-tour-stream="${escapeWorldTourHtml(embedUrl)}"
+                    data-world-tour-title="${escapeWorldTourHtml(selected.title)}"
+                    autoplay muted playsinline controls
+                ></video>
+                <div class="world-tour-video-loading">영상을 불러오는 중...</div>
+            </div>`;
+    } else if (embedUrl) {
+        mediaHtml = `
+            <div class="world-tour-video">
+                <iframe
+                    src="${escapeWorldTourHtml(embedUrl)}"
+                    title="${escapeWorldTourHtml(selected.title)}"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                    allowfullscreen
+                ></iframe>
+            </div>`;
+    } else if (snapshotUrl) {
+        // In-app snapshot playback for sources without an embeddable player
+        // (HK Traffic, USGS VolcView, Panomax, Roundshot). The image auto-
+        // refreshes via initWorldTourSnapshotRefresh after the DOM mounts.
+        const refreshMs = getWorldTourSnapshotRefreshMs(selected);
+        mediaHtml = `
+            <div class="world-tour-video world-tour-snapshot-hero">
+                <img
+                    class="world-tour-snapshot-img"
+                    src="${escapeWorldTourHtml(snapshotUrl)}"
+                    alt="${escapeWorldTourHtml(selected.title)} 실시간 스냅샷"
+                    data-world-tour-snapshot="${escapeWorldTourHtml(snapshotUrl)}"
+                    data-world-tour-snapshot-refresh="${refreshMs}"
+                    loading="eager"
+                    decoding="async"
+                />
+                <div class="world-tour-snapshot-overlay">
+                    <span class="world-tour-snapshot-badge">${escapeWorldTourHtml(sourceLabel)} 실시간 스냅샷</span>
+                    ${refreshMs > 0 ? `<span class="world-tour-snapshot-meta">${Math.round(refreshMs / 1000)}초마다 자동 새로고침</span>` : '<span class="world-tour-snapshot-meta">최신 캡처 이미지</span>'}
                 </div>
-            ` : embedUrl ? `
-                <div class="world-tour-video">
-                    <iframe
-                        src="${escapeWorldTourHtml(embedUrl)}"
-                        title="${escapeWorldTourHtml(selected.title)}"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        allowfullscreen
-                    ></iframe>
+            </div>`;
+    } else {
+        mediaHtml = `
+            <div class="world-tour-video world-tour-external-preview">
+                ${selected.thumbnailUrl ? `<img src="${escapeWorldTourHtml(selected.thumbnailUrl)}" alt="${escapeWorldTourHtml(selected.title)} preview" loading="lazy">` : ''}
+                <div class="world-tour-external-copy">
+                    <span>${escapeWorldTourHtml(sourceLabel)} 공식 플레이어</span>
+                    <strong>이 영상은 원본 사이트에서 안정적으로 재생됩니다.</strong>
+                    <a href="${escapeWorldTourHtml(selected.sourceUrl)}" target="_blank" rel="noopener">원본에서 보기</a>
                 </div>
-            ` : `
-                <div class="world-tour-video world-tour-external-preview">
-                    ${selected.thumbnailUrl ? `<img src="${escapeWorldTourHtml(selected.thumbnailUrl)}" alt="${escapeWorldTourHtml(selected.title)} preview" loading="lazy">` : ''}
-                    <div class="world-tour-external-copy">
-                        <span>${escapeWorldTourHtml(sourceLabel)} 공식 플레이어</span>
-                        <strong>이 영상은 원본 사이트에서 안정적으로 재생됩니다.</strong>
-                        <a href="${escapeWorldTourHtml(selected.sourceUrl)}" target="_blank" rel="noopener">원본에서 보기</a>
-                    </div>
-                </div>
-            `}
-        </section>
-    `;
+            </div>`;
+    }
+
+    return `<section class="world-tour-hero">${mediaHtml}</section>`;
+}
+
+// Auto-refreshes the snapshot img every N ms. Adds a cache-busting query
+// param so the browser doesn't serve a stale cached copy. Cleans up its
+// interval when the element is removed.
+let _worldTourSnapshotTimers = new WeakMap();
+function initWorldTourSnapshotRefresh() {
+    document.querySelectorAll('.world-tour-snapshot-img[data-world-tour-snapshot]').forEach(img => {
+        // De-dupe — avoid stacking intervals when re-render happens.
+        const prev = _worldTourSnapshotTimers.get(img);
+        if (prev) {
+            clearInterval(prev);
+            _worldTourSnapshotTimers.delete(img);
+        }
+        const refreshMs = Number(img.dataset.worldTourSnapshotRefresh || 0);
+        if (!refreshMs || refreshMs < 5000) return; // skip static-image sources
+        const baseUrl = img.dataset.worldTourSnapshot;
+        if (!baseUrl) return;
+        const timer = setInterval(() => {
+            if (!img.isConnected) {
+                clearInterval(timer);
+                _worldTourSnapshotTimers.delete(img);
+                return;
+            }
+            if (document.hidden) return; // pause when tab not visible
+            const sep = baseUrl.includes('?') ? '&' : '?';
+            img.src = `${baseUrl}${sep}_=${Date.now()}`;
+        }, refreshMs);
+        _worldTourSnapshotTimers.set(img, timer);
+    });
 }
 
 function renderWorldTourMapHero(selected, visibleCams) {
@@ -6023,7 +6088,10 @@ async function renderWorldTourCams(selectedId = state.selectedWorldTourId, optio
         if (state.worldTourViewMode === 'map') {
             requestAnimationFrame(() => initWorldTourMap(selected, visibleCams));
         } else {
-            requestAnimationFrame(initWorldTourVideoPlayback);
+            requestAnimationFrame(() => {
+                initWorldTourVideoPlayback();
+                initWorldTourSnapshotRefresh();
+            });
         }
     } catch (error) {
         console.error('[WorldTour] failed to load:', error);

--- a/scripts/enrich_world_tour_snapshots.py
+++ b/scripts/enrich_world_tour_snapshots.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Enrich data/world_tour_cams.json with `snapshotUrl` so that in-app
+image-refresh playback can replace the "open the original site" prompt
+for the four high-confidence sources where direct JPG access is permitted.
+
+Covered sources:
+  - hktraffic    : Hong Kong Transport Department traffic CCTV (CORS-open, ~1 min)
+  - usgsvolcano  : USGS VolcView ash-cam network            (CORS-open, ~5-10 min)
+  - panomax      : Panomax preview images                    (validate via HEAD)
+  - roundshot    : Roundshot dated CDN URLs                  (refresh requires
+                   collector re-run; in-app shows the latest snapshot captured
+                   at collection time — better than an external redirect.)
+
+Usage:
+    python3 scripts/enrich_world_tour_snapshots.py \
+        [--input data/world_tour_cams.json] \
+        [--no-validate-panomax]
+
+This script is idempotent — running it twice produces the same output.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from urllib import error as urlerror
+from urllib import request
+
+LOG = logging.getLogger("enrich_world_tour_snapshots")
+DEFAULT_INPUT = Path(__file__).resolve().parent.parent / "data" / "world_tour_cams.json"
+USER_AGENT = "cctv-snapshot-enricher/1.0 (+https://github.com/pyw31337/cctv)"
+PANOMAX_HEAD_TIMEOUT_SEC = 6
+
+
+def derive_snapshot(cam: dict) -> str | None:
+    """Return a best-effort direct JPG URL for the given world-tour cam.
+
+    Returns None for sources we don't yet know how to embed inline.
+    """
+    source_type = (cam.get("sourceType") or "").lower()
+    source_url = cam.get("sourceUrl") or ""
+    thumb_url = cam.get("thumbnailUrl") or ""
+
+    if source_type == "hktraffic":
+        # sourceUrl is already a direct .JPG (e.g. https://tdcctv.data.one.gov.hk/H422F2.JPG)
+        return source_url if source_url.lower().endswith(".jpg") else None
+
+    if source_type == "usgsvolcano":
+        # thumbnail: .../current-thumb.jpg → upgrade to full-size .../current.jpg
+        if thumb_url.endswith("-thumb.jpg"):
+            return thumb_url.replace("-thumb.jpg", ".jpg")
+        return thumb_url if thumb_url.endswith(".jpg") else None
+
+    if source_type == "panomax":
+        # panodata.panomax.com/cams/{id}/preview_og.jpg — used directly. Some cam IDs
+        # return 404; validation happens in a separate pass.
+        return thumb_url if thumb_url.endswith(".jpg") else None
+
+    if source_type == "roundshot":
+        # Date-stamped CDN URL. Won't auto-update inside the browser but the value
+        # is refreshed every time this script runs (e.g. via the daily GHA).
+        return thumb_url if thumb_url.endswith(".jpg") else None
+
+    return None
+
+
+def head_ok(url: str) -> bool:
+    """Return True if HEAD returns 200. Falls back to a tiny GET on 405."""
+    try:
+        req = request.Request(url, method="HEAD", headers={"User-Agent": USER_AGENT})
+        with request.urlopen(req, timeout=PANOMAX_HEAD_TIMEOUT_SEC) as resp:
+            return 200 <= resp.status < 300
+    except urlerror.HTTPError as exc:
+        if exc.code in (405, 501):  # method not allowed — try GET with byte range
+            try:
+                req = request.Request(
+                    url,
+                    headers={"User-Agent": USER_AGENT, "Range": "bytes=0-15"},
+                )
+                with request.urlopen(req, timeout=PANOMAX_HEAD_TIMEOUT_SEC) as resp:
+                    return 200 <= resp.status < 300
+            except Exception:  # pragma: no cover
+                return False
+        return False
+    except Exception:
+        return False
+
+
+def validate_panomax(snapshot_by_id: dict[str, str], max_workers: int = 16) -> set[str]:
+    """Return the set of cam IDs whose Panomax preview image returns HTTP 200."""
+    keep: set[str] = set()
+    if not snapshot_by_id:
+        return keep
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(head_ok, url): cam_id for cam_id, url in snapshot_by_id.items()}
+        for fut in as_completed(futures):
+            cam_id = futures[fut]
+            try:
+                if fut.result():
+                    keep.add(cam_id)
+            except Exception:
+                continue
+    return keep
+
+
+def run(input_path: Path, validate_panomax_flag: bool = True) -> dict:
+    raw = json.loads(input_path.read_text())
+    items = raw["items"]
+
+    counters: dict[str, int] = {}
+    panomax_candidates: dict[str, str] = {}
+
+    for cam in items:
+        snap = derive_snapshot(cam)
+        if not snap:
+            continue
+        source_type = (cam.get("sourceType") or "").lower()
+        if source_type == "panomax":
+            panomax_candidates[cam["id"]] = snap
+            continue
+        cam["snapshotUrl"] = snap
+        cam.setdefault("playbackKind", "snapshot")
+        counters[source_type] = counters.get(source_type, 0) + 1
+
+    if panomax_candidates:
+        if validate_panomax_flag:
+            LOG.info("Validating %d panomax preview URLs…", len(panomax_candidates))
+            keep = validate_panomax(panomax_candidates)
+        else:
+            keep = set(panomax_candidates.keys())
+        for cam in items:
+            if cam["id"] in keep:
+                cam["snapshotUrl"] = panomax_candidates[cam["id"]]
+                cam.setdefault("playbackKind", "snapshot")
+                counters["panomax"] = counters.get("panomax", 0) + 1
+
+    raw["snapshotEnrichmentMeta"] = {
+        "counts": counters,
+        "total": sum(counters.values()),
+    }
+    input_path.write_text(json.dumps(raw, ensure_ascii=False, indent=2) + "\n")
+    return counters
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", default=str(DEFAULT_INPUT), type=Path)
+    parser.add_argument("--no-validate-panomax", action="store_true",
+                        help="Skip the per-cam HEAD validation for Panomax (faster).")
+    parser.add_argument("--verbose", "-v", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+
+    counters = run(args.input, validate_panomax_flag=not args.no_validate_panomax)
+    LOG.info("Enriched %d cams with snapshotUrl", sum(counters.values()))
+    for source, count in sorted(counters.items()):
+        LOG.info("  %s: %d", source, count)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## 외부 비율 62% → 50%로 인하

사용자 요청: 가급적 원본 사이트로 이동하지 않고 우리 사이트 안에서 영상을 보여달라.

### 발견
- 외부 전용 940개 중 4개 소스(HK Transport / USGS / Panomax / Roundshot)의 JPG 엔드포인트가 CORS-open (`Access-Control-Allow-Origin: *`)이라 `<img>` 태그로 그대로 표시 가능. iframe 차단 정책의 영향을 받지 않음.
- SkylineWebcams(34)와 EarthCam(58)은 ToS상 외부 라이브 임베드를 금지하므로 외부 링크 유지.

### 구현
1. **`scripts/enrich_world_tour_snapshots.py`** — sourceUrl/thumbnailUrl 패턴에서 직접 JPG URL을 도출. Panomax는 병렬 HEAD 검증으로 404 제외 (40→30). HK Traffic은 sourceUrl이 이미 JPG, USGS는 `current-thumb.jpg`→`current.jpg`로 풀사이즈 승격, Roundshot은 dated CDN URL 그대로 (collector 재실행 시 갱신).
2. **`data/world_tour_cams.json`** — enrich 결과 인플레이스 적용. `snapshotUrl` + `playbackKind: "snapshot"` 필드 추가.
3. **`canPlayWorldTourInApp(cam)`** — `cam.snapshotUrl`도 playable로 인정.
4. **`renderWorldTourVideoHero`** — embedUrl/iframe/external-fallback 사이에 snapshot 분기 추가. `<img class=world-tour-snapshot-img>` + 좌하단 "실시간 스냅샷" 뱃지.
5. **`initWorldTourSnapshotRefresh()`** — per-image setInterval (HK 30s / USGS 60s / Panomax 5min / Roundshot 0 즉 새로고침 없음). 캐시버스트 `?_={timestamp}`. `document.hidden`이면 일시정지. `isConnected` 체크 + WeakMap으로 element 제거 시 자동 cleanup.
6. **CSS** — `.world-tour-snapshot-hero`, overlay 뱃지, mobile 보정.

### 결과
| 소스 | 추가 | 새로고침 |
|---|---|---|
| HK Transport | 70 | 30초 |
| USGS VolcView | 44 | 60초 |
| Panomax | 30 | 5분 |
| Roundshot | 37 | 정적(collector 갱신) |
| **합계** | **181** | — |

외부 비율: **62% → ~50%**. 사용자가 "원본 사이트에서 안정적으로 재생됩니다" 메시지를 보는 빈도가 약 19% 감소.

### 다음 단계
- PR1.7 후보: WorldCam(97)/Baltic(96)/Clima Ao Vivo(69)의 페이지 스크래핑 → YouTube videoId 추출 (Cloudflare Worker 또는 GHA collector). 성공률 60%라 가정하면 추가 ~160개 인앱 표시 가능 → 외부 비율을 ~40%대로 더 낮춤.
- 이번 PR1.6 완료 후 PR2(quality_summary GHA + Service Worker + 빌드해시)를 이어서 진행.