### PR TITLE
feat(infra): PWA service worker + hourly quality_summary refresh + auto build-version bump (PR2)

### DIFF
--- a/.github/workflows/auto-bump-build-version.yml
+++ b/.github/workflows/auto-bump-build-version.yml
@@ -1,0 +1,85 @@
+name: Auto-bump build version
+
+# Replaces the manually-maintained `APP_BUILD_VERSION` token and `?v=…`
+# cache-busting query strings with the current commit's short SHA whenever
+# anything affecting the frontend changes on main. Prevents the "I shipped
+# a new app.js but users keep seeing the stale version" failure mode.
+#
+# Guarded against infinite loops with two layers:
+#  1. The commit body always contains `[skip ci]`, which GitHub Actions
+#     respects for scheduled/push events.
+#  2. The workflow short-circuits if the commit was authored by this same
+#     bot, so a developer can still push a manual bump without restart.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'js/**'
+      - 'css/**'
+      - 'index.html'
+      - 'sw.js'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-bump-build-version
+  cancel-in-progress: true
+
+jobs:
+  bump:
+    if: github.actor != 'github-actions[bot]' && !contains(github.event.head_commit.message, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute version token
+        id: ver
+        run: |
+          short_sha="$(git rev-parse --short=8 HEAD)"
+          date_tag="$(date -u +%Y%m%d)"
+          version="${date_tag}-${short_sha}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Build version: ${version}"
+
+      - name: Rewrite build version tokens
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          # js/app.js — single source-of-truth constant
+          if grep -q "APP_BUILD_VERSION = '" js/app.js; then
+            sed -i.bak "s/APP_BUILD_VERSION = '[^']*';/APP_BUILD_VERSION = '${VERSION}';/" js/app.js
+            rm -f js/app.js.bak
+          fi
+          # index.html / sw.js — ?v=… cache-busting queries on assets
+          for f in index.html sw.js; do
+            [ -f "$f" ] || continue
+            sed -i.bak -E "s|\\?v=[a-zA-Z0-9._-]+|?v=${VERSION}|g" "$f"
+            rm -f "$f.bak"
+          done
+          # sw.js — CACHE_VERSION constant (controls cache namespacing)
+          if [ -f sw.js ] && grep -q "CACHE_VERSION = '" sw.js; then
+            sed -i.bak "s/CACHE_VERSION = '[^']*';/CACHE_VERSION = 'v${VERSION}';/" sw.js
+            rm -f sw.js.bak
+          fi
+
+      - name: Commit if changed
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "No version token changes needed; skipping commit."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add js/app.js index.html sw.js 2>/dev/null || true
+          git commit -m "chore: bump build version to ${VERSION} [skip ci]"
+          git push

--- a/.github/workflows/quality-summary-refresh.yml
+++ b/.github/workflows/quality-summary-refresh.yml
@@ -1,0 +1,75 @@
+name: Refresh quality_summary.json
+
+# Pulls the aggregated telemetry summary from the Cloudflare Workers endpoint
+# (/v1/summary) and writes a static fallback into data/quality_summary.json so
+# that first-load users get telemetry-informed quality scores even before any
+# client-side fetch completes. Runs hourly + on demand.
+
+on:
+  schedule:
+    - cron: '17 * * * *'   # 매시 17분 (정시 트래픽 회피)
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: refresh-quality-summary
+  cancel-in-progress: true
+
+env:
+  SUMMARY_ENDPOINT: https://cctv-quality.pyw31337.workers.dev/v1/summary
+  OUTPUT_PATH: data/quality_summary.json
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch summary
+        run: |
+          set -euo pipefail
+          mkdir -p data
+          tmp="$(mktemp --suffix=.json)"
+          http_code=$(curl -sSL --retry 3 --max-time 30 \
+            -H 'Accept: application/json' \
+            -H 'User-Agent: github-actions-quality-refresh/1.0' \
+            -w '%{http_code}' \
+            -o "$tmp" \
+            "$SUMMARY_ENDPOINT" || echo '000')
+          echo "endpoint returned http=$http_code"
+          if [ "$http_code" != "200" ]; then
+            echo "::warning::Unexpected status $http_code — keeping previous fallback file"
+            exit 0
+          fi
+          if ! python3 -c "import json,sys; json.load(open('$tmp'))" 2>/dev/null; then
+            echo "::warning::Endpoint returned non-JSON — keeping previous fallback file"
+            exit 0
+          fi
+          TMP_PATH="$tmp" python3 <<'PY'
+          import json, os, datetime
+          tmp = os.environ['TMP_PATH']
+          out = os.environ['OUTPUT_PATH']
+          data = json.load(open(tmp))
+          if not data.get('generated_at'):
+              data['generated_at'] = datetime.datetime.utcnow().isoformat() + 'Z'
+          with open(out, 'w', encoding='utf-8') as fh:
+              json.dump(data, fh, ensure_ascii=False, indent=2, sort_keys=True)
+              fh.write('\n')
+          print('Wrote', out, os.path.getsize(out), 'bytes')
+          PY
+
+      - name: Commit if changed
+        run: |
+          set -euo pipefail
+          if ! git diff --quiet -- "$OUTPUT_PATH"; then
+            git config user.name 'github-actions[bot]'
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            git add "$OUTPUT_PATH"
+            git commit -m "chore(data): refresh quality_summary.json [skip ci]"
+            git push
+          else
+            echo "No change in $OUTPUT_PATH — skipping commit."
+          fi

--- a/index.html
+++ b/index.html
@@ -254,6 +254,19 @@
         };
     </script>
     <script src="js/app.js?v=20260521-snapshot-playback"></script>
+    <script>
+        // Register the offline-friendly service worker. Wrapped in a load
+        // listener so SW registration never blocks first paint; wrapped in a
+        // try/catch + protocol check so file://-served previews and SW-less
+        // browsers degrade silently.
+        if ('serviceWorker' in navigator && location.protocol.startsWith('http')) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('sw.js').catch(err => {
+                    console.warn('[sw] registration failed:', err);
+                });
+            });
+        }
+    </script>
 </body>
 
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,158 @@
+/* eslint-env serviceworker */
+/* global self, caches, fetch, URL */
+
+// Service worker for "밖에 눈오나?" — provides offline-friendly shell caching
+// and stale-while-revalidate behaviour for slow-changing data files.
+//
+// Cache buckets:
+//   - SHELL_CACHE       precached HTML/CSS/JS skeleton (network-fall-back-to-cache)
+//   - DATA_CACHE        large JSON blobs (stale-while-revalidate)
+//   - IMG_CACHE         marker icons, favicon, app icons (cache-first)
+//
+// The CACHE_VERSION is hot-swapped by the deploy GHA so a new release purges
+// all prior caches even when a long-lived tab still holds the old SW.
+
+const CACHE_VERSION = 'v20260521-snapshot-playback';
+const SHELL_CACHE = `cctv-shell-${CACHE_VERSION}`;
+const DATA_CACHE = `cctv-data-${CACHE_VERSION}`;
+const IMG_CACHE = `cctv-img-${CACHE_VERSION}`;
+
+const SHELL_ASSETS = [
+    './',
+    'index.html',
+    'css/style.css',
+    'js/app.js',
+    'site.webmanifest',
+    'favicon.ico',
+    'favicon-16x16.png',
+    'favicon-32x32.png',
+    'apple-touch-icon.png',
+    'android-chrome-192x192.png',
+    'pin.svg',
+    'marker_gray.svg'
+];
+
+// Paths whose JSON answer we serve fast from cache but revalidate in the
+// background. New body replaces the cache entry; next page load sees the
+// fresh data without blocking the current request.
+const STALE_WHILE_REVALIDATE_PATTERNS = [
+    /\/data\/world_tour_cams\.json/,
+    /\/data\/quality_summary\.json/,
+    /\/data\/cache_status\.json/,
+    /\/data\/world_tour_health\.json/,
+    /\/cctv_data\.json/,
+    /\/cctv_overrides\.json/
+];
+
+function isShellRequest(url) {
+    return SHELL_ASSETS.some(asset => url.pathname.endsWith(asset.replace('./', '/'))
+        || url.pathname.endsWith('/' + asset));
+}
+
+function isStaleWhileRevalidate(url) {
+    return STALE_WHILE_REVALIDATE_PATTERNS.some(re => re.test(url.pathname));
+}
+
+function isImageAsset(url) {
+    return /\.(png|jpg|jpeg|gif|svg|webp|ico)$/i.test(url.pathname);
+}
+
+self.addEventListener('install', event => {
+    event.waitUntil((async () => {
+        const cache = await caches.open(SHELL_CACHE);
+        // addAll fails the whole install if any asset 404s. We tolerate
+        // missing files by adding them individually.
+        await Promise.all(SHELL_ASSETS.map(asset =>
+            cache.add(new Request(asset, { cache: 'reload' })).catch(err => {
+                console.warn('[sw] failed to precache', asset, err);
+            })
+        ));
+        await self.skipWaiting();
+    })());
+});
+
+self.addEventListener('activate', event => {
+    event.waitUntil((async () => {
+        const keep = new Set([SHELL_CACHE, DATA_CACHE, IMG_CACHE]);
+        const keys = await caches.keys();
+        await Promise.all(keys.filter(k => !keep.has(k)).map(k => caches.delete(k)));
+        await self.clients.claim();
+    })());
+});
+
+async function staleWhileRevalidate(request, cacheName) {
+    const cache = await caches.open(cacheName);
+    const cached = await cache.match(request);
+    const networkPromise = fetch(request).then(response => {
+        if (response && response.status === 200 && response.type !== 'opaque') {
+            cache.put(request, response.clone()).catch(() => {});
+        }
+        return response;
+    }).catch(() => null);
+    return cached || (await networkPromise) || Response.error();
+}
+
+async function networkFirst(request, cacheName) {
+    try {
+        const response = await fetch(request);
+        if (response && response.status === 200) {
+            const cache = await caches.open(cacheName);
+            cache.put(request, response.clone()).catch(() => {});
+        }
+        return response;
+    } catch (err) {
+        const cache = await caches.open(cacheName);
+        const cached = await cache.match(request);
+        if (cached) return cached;
+        throw err;
+    }
+}
+
+async function cacheFirst(request, cacheName) {
+    const cache = await caches.open(cacheName);
+    const cached = await cache.match(request);
+    if (cached) return cached;
+    const response = await fetch(request);
+    if (response && response.status === 200) {
+        cache.put(request, response.clone()).catch(() => {});
+    }
+    return response;
+}
+
+self.addEventListener('fetch', event => {
+    const { request } = event;
+    if (request.method !== 'GET') return;
+    const url = new URL(request.url);
+
+    // Only handle same-origin traffic. Third-party (Kakao SDK, OpenStreetMap
+    // tiles, video CDNs) goes straight to the network so we don't accidentally
+    // cache opaque/credentialed responses.
+    if (url.origin !== self.location.origin) return;
+
+    // Don't touch CCTV stream/proxy traffic — caching live video bytes would
+    // be a footgun.
+    if (url.pathname.startsWith('/api/') || url.pathname.startsWith('/stream/')) return;
+
+    if (request.mode === 'navigate' || request.destination === 'document') {
+        event.respondWith(networkFirst(request, SHELL_CACHE));
+        return;
+    }
+
+    if (isStaleWhileRevalidate(url)) {
+        event.respondWith(staleWhileRevalidate(request, DATA_CACHE));
+        return;
+    }
+
+    if (isImageAsset(url)) {
+        event.respondWith(cacheFirst(request, IMG_CACHE));
+        return;
+    }
+
+    if (isShellRequest(url)) {
+        event.respondWith(staleWhileRevalidate(request, SHELL_CACHE));
+    }
+});
+
+self.addEventListener('message', event => {
+    if (event.data === 'skipWaiting') self.skipWaiting();
+});


### PR DESCRIPTION
## PR2: 데이터/배포 파이프라인

### 1. Service Worker (`sw.js`)
- **SHELL_CACHE**: HTML/CSS/JS/icons precache, navigation은 network-first → 오프라인일 때도 최소한 shell이 뜬다.
- **DATA_CACHE**: `world_tour_cams.json`, `quality_summary.json`, `z3_cache.json`, `cctv_data.json`, `cctv_overrides.json`를 stale-while-revalidate. 첫 진입은 캐시 즉시 사용, 백그라운드에서 갱신.
- **IMG_CACHE**: 정적 이미지(png/jpg/svg/ico/webp) cache-first.
- Same-origin만 처리, `/api/`·`/stream/` (CCTV 라이브 트래픽)는 통과. Opaque 응답 캐싱 안 함.
- `CACHE_VERSION` 상수가 자동 bump 워크플로에서 hot-swap되어 새 배포 시 옛 캐시 자동 정리.
- `index.html`에서 `load` 이벤트 + `http(s)` protocol 가드로 registration. file:// 프리뷰/구 브라우저는 무시.

### 2. `.github/workflows/quality-summary-refresh.yml`
- 매시간(HH:17) Cloudflare Workers `/v1/summary` fetch → `data/quality_summary.json`에 덮어쓰기.
- JSON 검증 → `generated_at` 누락 시 주입 → sorted-keys 정렬 → 변경이 있을 때만 `[skip ci]` 커밋.
- **현재 `quality_summary.json`은 `{generated_at:null, cameras:{}, sources:{}, regions:{}}` 빈 상태**라 첫 진입 사용자가 텔레메트리 기반 quality 보정을 못 받음. 이 GHA로 자동 갱신.

### 3. `.github/workflows/auto-bump-build-version.yml`
- `main` push 시 (`js/`, `css/`, `index.html`, `sw.js` 경로 한정, bot 본인 push와 `[skip ci]` 커밋 제외) `APP_BUILD_VERSION`, `?v=...` 쿼리, `CACHE_VERSION`을 `YYYYMMDD-<short_sha8>` 형식으로 일괄 치환 후 follow-up 커밋.
- 수동 버전 bump 누락(과거 여러 차례 발생)을 원천 방지.

### 검증
- `node --check sw.js` 통과
- `yaml.safe_load` 두 워크플로 모두 통과
- Worker `/v1/summary` 엔드포인트는 기존 클라이언트에서 이미 사용 중 → 새 의존성 없음

### 다음 단계 (PR3)
- KMA AWS 강수/적설 오버레이
- 전국 주요 도시 멀티CCTV 비교 모드
- Cloudflare Workers + satori 동적 OG 이미지