### PR TITLE
feat(world-tour): in-app snapshot playback for 168 more cams (Baltic 71 + WorldCam 97) — external ratio 62%→39%

### DIFF
--- a/data/world_tour_cams.json
+++ b/data/world_tour_cams.json
@@ -20076,7 +20076,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/a-coruna-playa-del-matadero-live.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-37247-abriola-monteforte-serra-tuoppo",
@@ -20103,7 +20105,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.img.worldcam.pl/webcams/420x236/2026-05-21/37247.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-17838-abries-ristolas-lechalp",
@@ -20130,7 +20134,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/abries-ristolas-l-echalp-ip-came.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-21355-abukuma-river",
@@ -20157,7 +20163,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/abukuma-ip-camera.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-25406-acceglio-borgo-frere",
@@ -20184,7 +20192,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.img.worldcam.pl/webcams/420x236/2026-05-21/25406.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-30224-acquapendente-torre-alfina",
@@ -20211,7 +20221,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/64f5d1608af84.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-33445-agon-coutainville-beach",
@@ -20238,7 +20250,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/agon-coutainville-streaming.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-20201-akaigawa-kiroro-snow-world",
@@ -20265,7 +20279,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/akaigawa-kiroro-snow-world-camer.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-14053-akita-akita-international-airport",
@@ -20292,7 +20308,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/akita-port-lotniczy-akita-webcam.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-36177-akiota-osorakan-snow-park",
@@ -20319,7 +20337,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/akiota-osorakan-snow-park-liveca.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-35552-amakusa-ushibukamachi",
@@ -20346,7 +20366,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/67ea462aed71d.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-16507-amami-airport",
@@ -20373,7 +20395,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/amami-port-lotniczy-stream.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-35479-ambert-aerodrome-dambert-le-poyet",
@@ -20400,7 +20424,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/69e74b1bf21f9-ambert-lotnisko-ambert-le-poyet-.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-17446-amiens-panoramic-view",
@@ -20427,7 +20453,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.img.worldcam.pl/webcams/420x236/2026-05-21/17446.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-26934-asan-traffic",
@@ -20454,7 +20482,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/632032814e769.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-32944-baengnyeongdo-dumujin",
@@ -20481,7 +20511,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/baengnyeongdo-dumujin-port-strea.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-32338-bari-pane-e-pomodoro-beach",
@@ -20508,7 +20540,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.img.worldcam.pl/webcams/420x236/2026-05-21/32338.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-36223-bukdo-myeon-jangbongdo-beach",
@@ -20535,7 +20569,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/bukdo-myeon-beach-kameros.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-35705-bukhansan-national-park-sapaesan",
@@ -20562,7 +20598,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/bukhansan-national-park-live.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-20605-busan-gwangan-bridge",
@@ -20589,7 +20627,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/6669d8f28fb2c.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-32627-busan-haeundae-songjeong-beach",
@@ -20616,7 +20656,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/gangneung-plaza-ip-camera.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-34790-busan-haeundae-beach",
@@ -20643,7 +20685,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/677fe040ea19a.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-34766-busan-millak-waterside-park",
@@ -20670,7 +20714,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/pusan-kameros.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-25898-calais-beach",
@@ -20697,7 +20743,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/calais-plaza-streaming.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-15564-cambrils-beach",
@@ -20724,7 +20772,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.img.worldcam.pl/webcams/420x236/2026-05-20/15564.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-19412-cannes-le-vieux-port",
@@ -20751,7 +20801,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/cannes-le-vieux-port-na-zywo.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-24460-civitavecchia-roman-dock",
@@ -20778,7 +20830,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/civitavecchia-darsena-romana-ip-.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-27785-fuengirola-los-boliches-beach",
@@ -20805,7 +20859,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/fuengirola-playa-de-los-boliches.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-33329-fujikawaguchiko-mount-fuji",
@@ -20832,7 +20888,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/66c31a33ebc0c.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-32381-jeju-jeju-international-airport",
@@ -20859,7 +20917,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/czedzu-port-lotniczy-streaming.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-36578-khao-lak-valhalla-teahouse-sunset-beach",
@@ -20886,7 +20946,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/68a031e985aef.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-13249-kuji-harbour",
@@ -20913,7 +20975,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/63910c5d6ae36.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-4362-majorca-cala-bona-harbour",
@@ -20940,7 +21004,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/majorka-cala-bona-streaming.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-25855-mallorca-palma-nova-beach",
@@ -20967,7 +21033,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/majorka-palma-nova-plaza-livecam.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-6610-marne-la-vallee-disneyland-resort-paris",
@@ -20994,7 +21062,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/66472b4728a0f-marne-la-vallee-disneyland-resor.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-27374-menorca-mahon-marina",
@@ -21021,7 +21091,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/minorka-mahon-marina-camera.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-12219-menton-beach",
@@ -21048,7 +21120,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/mentona-plaza-ip-camera.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-31601-paris-eiffel-tower",
@@ -21075,7 +21149,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.img.worldcam.pl/webcams/420x236/2026-05-21/31601.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-32476-pattaya-beach-road",
@@ -21102,7 +21178,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/67e1462435502.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-23959-pattaya-traffic",
@@ -21129,7 +21207,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/pattaya-kamery-drogowe-na-zywo.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-35503-phuket-kamala-nakalay-beach",
@@ -21156,7 +21236,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.img.worldcam.pl/webcams/420x236/2026-05-21/35503.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-1716-phuket-karon-beach",
@@ -21183,7 +21265,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/67d00f5b4cb3d.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-36492-phuket-kata-beach",
@@ -21210,7 +21294,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/688de1a251c16.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-7697-phuket-patong-beach",
@@ -21237,7 +21323,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/11241045201507.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-4194-sapporo-odori-park",
@@ -21264,7 +21352,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/sapporo-odori-park-preview.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-31962-sardinia-alghero-maria-pia-beach",
@@ -21291,7 +21381,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.img.worldcam.pl/webcams/420x236/2026-05-21/31962.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-30023-seoul-hangang-river",
@@ -21318,7 +21410,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/64d75ade25c9b.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-17247-seoul-namsan-seoul-tower",
@@ -21345,7 +21439,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/seul-kamerka.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-32206-seoul-seoul-station-square",
@@ -21372,7 +21468,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/660d6fc1e166a.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-20409-tokyo-chidorigafuchi-park-sakura",
@@ -21399,7 +21497,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/tokio-chidorigafuchi-park-live.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-1681-ueda-cherry-blossom",
@@ -21426,7 +21526,9 @@
       "sourceOnly": true,
       "stabilityScore": 76,
       "qualityScore": 76,
-      "qualityTier": "good"
+      "qualityTier": "good",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/ueda-kwiaty-kwitnacej-wisni-saku.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "webcamtaxi-sydney-harbour-webcamtaxi",
@@ -25610,7 +25712,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/a-coruna-ip-camera.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-37253-a24-and-a25-motorways-rome-teramo-pescara",
@@ -25637,7 +25741,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/69218aff9ecab.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-29558-a6-highway-turin-savona",
@@ -25664,7 +25770,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/autostrada-a6-turyn-savona-obraz.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-19853-abano-terme-piazza-colombo",
@@ -25691,7 +25799,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/abano-terme-camera.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-20282-abetone-several-views",
@@ -25718,7 +25828,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/abetone-centrum-kamerka.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-8076-abetone-ski-center-ovovia",
@@ -25745,7 +25857,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.img.worldcam.pl/webcams/420x236/2026-05-21/8076.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-24741-abetone-val-di-luce",
@@ -25772,7 +25886,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/61432f1ac6106.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-33253-accous-paragliding",
@@ -25799,7 +25915,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/accous-paragliding-stream.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-35883-acquafondata-piazza-dei-caduti",
@@ -25826,7 +25944,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.img.worldcam.pl/webcams/420x236/2026-05-21/35883.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-18903-aix-les-bains-grand-port",
@@ -25853,7 +25973,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/66c881a100c50-aix-les-bains-grand-port-kamerka.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-29992-aix-les-bains-lake-bourget",
@@ -25880,7 +26002,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.img.worldcam.pl/webcams/420x236/2026-05-21/29992.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-36626-aizuwakamatsu-higashiyama-onsen-japanese-garden",
@@ -25907,7 +26031,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/68ac23b81a6a7.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-32404-akishima-gas-station",
@@ -25934,7 +26060,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/662770ffe9fef.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-8709-alencon-aerodrome-dalencon-valframbert",
@@ -25961,7 +26089,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/alencon-aerodrome-d-alencon-valf.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-11524-alpe-dhuez",
@@ -25988,7 +26118,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/l-alpe-d-huez-livecam.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-29957-amakusa-several-views",
@@ -26015,7 +26147,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/64c611a00afd8.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-8879-anamizu",
@@ -26042,7 +26176,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/11292328201515.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-1604-aomori",
@@ -26069,7 +26205,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/aomori-kamerka.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-32936-baengnyeongdo-canal",
@@ -26096,7 +26234,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/baengnyeongdo-baekryeong-island-.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-32945-baengnyeongdo-gobongpo",
@@ -26123,7 +26263,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/668bab5712853-baengnyeongdo-baekryeong-island-.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-14097-bangkok-cctv-traffic",
@@ -26150,7 +26292,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/bangkok-sathorn-gardens-obraz.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-13937-bangkok-mahatun-plaza",
@@ -26177,7 +26321,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/64edb8f3519c0.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-18945-bangkok-petchaburi-road",
@@ -26204,7 +26350,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/637e23b768ec1.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-33765-bangkok-save-one-go-market",
@@ -26231,7 +26379,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/bangkok-save-one-go-market-kamer.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-36808-bangkok-soi-sukhumvit-11",
@@ -26258,7 +26408,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/68c4312047fec.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-36809-bangkok-sukhumvit-rd",
@@ -26285,7 +26437,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/68c4317b545f0.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-7804-bangkok-traffic",
@@ -26312,7 +26466,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/bangkok-kamery-drogowe-camera.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-8267-cannobio-piazza-lago",
@@ -26339,7 +26495,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/cannobio-piazza-lago-ip-camera.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-14104-cha-am-thew-talay-estate",
@@ -26366,7 +26524,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/665ede91a0a0b-cha-am-thew-talay-estate-obraz.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-17101-chiang-mai-university",
@@ -26393,7 +26553,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/chiang-mai-pantip-plaza-kameros.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-14106-coast-several-views",
@@ -26420,7 +26582,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/wybrzea-zbir-kamer-camera.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "aurorainfo-hankasalmi-all-sky",
@@ -26505,7 +26669,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/660546d3ab1f8-krabi-ao-nang-livecam.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-26137-lazise-lake-garda",
@@ -26532,7 +26698,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/627a34d4e8c7b.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "aurorainfo-abisko-lights-over-lapland",
@@ -26588,7 +26756,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.img.worldcam.pl/webcams/420x236/2026-05-21/5964.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-1059-nice-promenade-des-anglais",
@@ -26615,7 +26785,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/nicea-promenada-anglikow-livecam.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-5371-oppido-lucano-piazza-marconi",
@@ -26642,7 +26814,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/oppido-lucano-piazza-marconi-str.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "aurorainfo-porin-karhunvartijat-all-sky",
@@ -26698,7 +26872,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.img.worldcam.pl/webcams/420x236/2026-05-21/11874.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-11345-salou-costa-de-llevant",
@@ -26725,7 +26901,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/salou-costa-de-llevant-streaming.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-3669-sardinia-villasimius-spiaggia-di-simius",
@@ -26752,7 +26930,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/villasimius-port-jachtowy-obraz.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-18234-sarralbe-storks",
@@ -26779,7 +26959,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/696779e61f78c-sarralbe-bociany-kameros.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-35774-seoul-gyeongbokgung",
@@ -26806,7 +26988,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/6808b908171a0.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-40475-seoul-samcheong",
@@ -26833,7 +27017,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/69f7590f0870f.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-36718-seoul-traffic",
@@ -26860,7 +27046,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/seul-kamery-drogowe-camera.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "aurorainfo-skibotn-all-sky",
@@ -26916,7 +27104,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/690b201701479-sydney-harbour-bridge-kamerka.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-5108-tokyo-sky-tree-panoramic-view",
@@ -26943,7 +27133,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/tokio-sky-tree-webcam.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "worldcam-4407-torremolinos-casa-antonio-promenade",
@@ -26970,7 +27162,9 @@
       "sourceOnly": true,
       "stabilityScore": 71,
       "qualityScore": 71,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://www.worldcam.pl/images/webcams/420x236/61598fb76a69e-torremolinos-casa-antonio-promen.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "aurorainfo-yellowknife",
@@ -30383,7 +30577,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_DE_Bayreuth_city_center_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-switzerland-lausanne-bessieres-bridge",
@@ -30464,7 +30660,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_PL_Bolkow_castle_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-romania-brasov-brasov-city-center",
@@ -30518,7 +30716,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_ISR_Caesarea_beach_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-spain-la-coruna-caion-beach",
@@ -30545,7 +30745,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_ES_Playa_de_Caion_La_Coruna_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-netherlands-amsterdam-city-centre-observation-singel-hotel-amsterdam",
@@ -30599,7 +30801,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_US_Florida_Clearwater_Beach_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-latvia-daugavpils-daugavpils-unity-square",
@@ -30626,7 +30830,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/Daugavpils_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-ukraine-zaporizhzhia-festival-square",
@@ -30680,7 +30886,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_UK_Folkestone_port_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-united-states-gatlinburg-gatlinburg-skyline",
@@ -30788,7 +30996,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/JurmalaRomantica_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-lithuania-kaunas-kaunas-city-view",
@@ -30842,7 +31052,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_ES_Lanzarote_Famara_beach_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-latvia-rezekne-liberation-square-latgalian-mara",
@@ -30869,7 +31081,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/Rezekne_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-latvia-jurmala-majori-beach",
@@ -30896,7 +31110,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/majoriSavers1_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-lithuania-palanga-manciske-beach",
@@ -30923,7 +31139,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_LT_Palanga_Manciske_beach_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-united-states-marco-island-marco-island-beach",
@@ -30950,7 +31168,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_US_Marco_Island_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-united-states-new-york-new-york",
@@ -30977,7 +31197,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/US_new_york_city_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-russia-novosibirsk-novosibirsk-city-view",
@@ -31004,7 +31226,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_RU_Novosibirsk_city_view_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-united-states-ocean-city-ocean-city-boardwalk",
@@ -31031,7 +31255,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_US_Ocean_City_Boardwalk_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-united-kingdom-hunstanton-old-hunstanton-beach",
@@ -31058,7 +31284,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_UK_Old_Hunstanton_Beach_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-mexico-playa-del-carmen-palms-beach",
@@ -31085,7 +31313,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_MEX_Playa_del_Carmen_Playa_palms_beach_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-vietnam-phan-thiet-phan-thiet-beach",
@@ -31112,7 +31342,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_VI_Phan_Thiet_beach_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-italy-la-spezia-saint-bon-square",
@@ -31166,7 +31398,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_VE_Porlamar_beach_Margarita_island_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-united-states-portland-portland-city-view",
@@ -31193,7 +31427,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_US_Portland_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-finland-porvoo-porvoo-city-view",
@@ -31220,7 +31456,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_FI_Porvoo_city_view_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-italy-riccione-riccione-beach-panorama",
@@ -31247,7 +31485,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_IT_Riccione_beach_panorama_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-latvia-riga-domcik",
@@ -31301,7 +31541,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_RU_Sochi_Roza_hutor_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-argentina-santa-clara-del-mar-santa-clara-del-mar-beach",
@@ -31328,7 +31570,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_AR_Santa_Clara_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-south-korea-seoul-seoul-city-center",
@@ -31382,7 +31626,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_LV_Rozu_laukums_Cesis_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-sweden-stockholm-stockholm-city-view",
@@ -31436,7 +31682,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_SB_Subotica_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-estonia-tallinn-tallinn-bay-panorama",
@@ -31463,7 +31711,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/PanoTallinnMoving_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-united-states-tybee-island-tybee-island-beach",
@@ -31544,7 +31794,9 @@
       "sourceOnly": true,
       "stabilityScore": 70,
       "qualityScore": 70,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_PT_Vilamoura_beach_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "africam-hyena-pan",
@@ -38894,7 +39146,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/rigaPanorama_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-greece-kefalonia-cephalonia-argostoli",
@@ -38921,7 +39175,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_GR_Kefalonia_Argostoli_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-bosnia-and-herzegovina-medjugorje-blue-cross",
@@ -38948,7 +39204,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_BSN_Medjugorje_Blue_cross_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-italy-caorle-caorle-sea-promenade",
@@ -38975,7 +39233,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_IT_Caorle_sea_promenade_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-italy-civita-di-bagnoregio-civita-di-bagnoregio",
@@ -39002,7 +39262,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_IT_Civita_di_Bagnoregio_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-italy-rome-colosseum",
@@ -39029,7 +39291,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_IT_Rome_Colosseum_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-latvia-liepaja-concert-hall-great-amber",
@@ -39056,7 +39320,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/Liepaja_Lielais_Dzintars_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-egypt-hurghada-el-gouna",
@@ -39083,7 +39349,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_EG_Hurgada_El_Gouna_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-greece-paxi-gaios",
@@ -39110,7 +39378,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_GR_Paxi_Gaios_port_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-united-states-galilee-rhode-island-galilee",
@@ -39137,7 +39407,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_US_Rhode_Island_Galilee_Port_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-norway-geiranger-geirangerfjord",
@@ -39191,7 +39463,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_GE_hamburg_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-china-hekou-hekou-guomen-port",
@@ -39245,7 +39519,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_IS_Husavik_port_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-iceland-isafjordur-isafjordur",
@@ -39272,7 +39548,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_IS_Isafjordur_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-portugal-madeira-jardim-do-mar",
@@ -39299,7 +39577,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_PT_Madeira_Jardim_do_Mar_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-croatia-murter-jezera",
@@ -39326,7 +39606,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_CR_Jezera_Murter_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-latvia-jurmala-jurmala-view-semarah-hotel",
@@ -39353,7 +39635,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/Semara_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-finland-rauma-kylmapihlaja-island-ligthouse",
@@ -39407,7 +39691,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_Swiss_Lugano_Lake_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-poland-szczecin-lastadia-bulevard",
@@ -39434,7 +39720,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_PL_Szczecin_Lastadia_boulevard_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-latvia-jurmala-majori",
@@ -39461,7 +39749,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/majoriSavers2_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-russia-volgograd-mamayev-kurgan",
@@ -39488,7 +39778,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_RU_Volgograd_Mamayev_Kurgan_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-lithuania-klaipeda-melnrages-molas",
@@ -39515,7 +39807,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_LT_klaipeda_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-greece-crete-mesochori",
@@ -39542,7 +39836,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_GR_Mesochori_Crete_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-italy-naples-molo-beverello",
@@ -39569,7 +39865,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_IT_Molo_Beverello_Napoli_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-estonia-parnu-parnu",
@@ -39596,7 +39894,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/parnu_cityhall_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-italy-sarzana-piazza-giacomo-matteotti",
@@ -39650,7 +39950,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_IT_Piazza_della_liberta_Macerata_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-scotland-pitlochry-pitlochry-town",
@@ -39677,7 +39979,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_GB_Scotland_Pitlochry_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-spain-mallorca-port-dandratx",
@@ -39731,7 +40035,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_IT_Port_of_Rimini_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-germany-munster-prinzipalmarkt-street",
@@ -39758,7 +40064,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_GE_Prinzipalmarkt_Munster_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-finland-rauma-rauma-market-place",
@@ -39812,7 +40120,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_RU_Sochi_Roza_Dolina_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-united-states-sanibel-sanibel-coast",
@@ -39839,7 +40149,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_BR_Sao_Paolo_panorama_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-portugal-azores-santa-maria",
@@ -39866,7 +40178,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_PT_Santa_Maria_Azores_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-argentina-santiago-del-estero-santiago-del-estero",
@@ -39893,7 +40207,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_AR_Santiago_del_Estero_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-poland-sopot-sopot-pier",
@@ -39920,7 +40236,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_PL_Pier_Sopot_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-united-states-st-louis-st-louis",
@@ -39947,7 +40265,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_US_St_Louis_Missouri_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-taiwan-taipei-taipei-down-town",
@@ -40001,7 +40321,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_NZ_Taupo_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-italy-palermo-teatro-massimo",
@@ -40055,7 +40377,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_US_Texas_State_University_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-italy-venice-the-grand-canal",
@@ -40109,7 +40433,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_GR_Lefkada_Tsoukalades_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-italy-turin-turin",
@@ -40136,7 +40462,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_IT_Turin_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-united-kingdom-uppingham-uppingham-market-place",
@@ -40163,7 +40491,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_UK_Uppingham_market_place_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-bulgaria-veliko-tarnovo-veliko-tarnovo-panoramic-view",
@@ -40190,7 +40520,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_BG_Veliko_Tarnovo_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-italy-venice-view-from-hotel-bel-sito",
@@ -40217,7 +40549,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_IT_venecia_Bel_Sito_hotel_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "baltic-cameras-israel-jerusalem-western-wall",
@@ -40271,7 +40605,9 @@
       "sourceOnly": true,
       "stabilityScore": 65,
       "qualityScore": 65,
-      "qualityTier": "fair"
+      "qualityTier": "fair",
+      "snapshotUrl": "https://thumbs.balticlivecam.com/blc/p_TR_Belek_Xanadu_hotel_sm.jpg",
+      "playbackKind": "snapshot"
     },
     {
       "id": "youtube-search-am9zczlmjyo",
@@ -42099,8 +42435,10 @@
       "roundshot": 37,
       "usgsvolcano": 44,
       "hktraffic": 70,
-      "panomax": 30
+      "panomax": 30,
+      "baltic": 71,
+      "worldcam": 97
     },
-    "total": 181
+    "total": 349
   }
 }

--- a/js/app.js
+++ b/js/app.js
@@ -4956,6 +4956,8 @@ function getWorldTourSnapshotRefreshMs(cam) {
     const sourceType = (cam?.sourceType || '').toLowerCase();
     if (sourceType === 'hktraffic') return 30_000;     // HK CCTV: 30s
     if (sourceType === 'usgsvolcano') return 60_000;   // USGS volc: 1min
+    if (sourceType === 'baltic') return 2 * 60_000;    // Baltic thumbs CDN: ~2min
+    if (sourceType === 'worldcam') return 3 * 60_000;  // WorldCam live JPG: ~3min
     if (sourceType === 'panomax') return 5 * 60_000;   // Panomax: 5min
     if (sourceType === 'roundshot') return 0;          // Roundshot URL is dated; no refresh
     return 60_000;

--- a/scripts/enrich_world_tour_v2.py
+++ b/scripts/enrich_world_tour_v2.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Round 2 of in-app playback expansion.
+
+Adds `snapshotUrl` for two more sources:
+
+  - baltic   : 96 cams. Their `thumbs.balticlivecam.com/blc/*_sm.jpg` URLs are
+               live thumbnails that the CDN refreshes every ~30-60 minutes
+               (verified Last-Modified). The other Baltic thumbnail bucket
+               (`balticlivecam.com/images/webcam_*-453x255.jpg`) is a STATIC
+               2021-era promo image; we exclude it.
+  - worldcam : 97 cams. Each cam page on worldcam.eu embeds a per-cam live
+               JPG at `https://www.worldcam.pl/images/webcams/420x236/<slug>.jpg`.
+               The slug is per-page and not derivable, so we scrape it.
+
+Both sources require HEAD-validation because some cams are dead.
+
+Run after `enrich_world_tour_snapshots.py` (round 1). Both scripts are
+idempotent and only ever ADD `snapshotUrl` to cams that don't have it.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from urllib import error as urlerror
+from urllib import request
+
+LOG = logging.getLogger("enrich_world_tour_v2")
+DEFAULT_INPUT = Path(__file__).resolve().parent.parent / "data" / "world_tour_cams.json"
+UA = "Mozilla/5.0 (compatible; CctvWorldTourEnricher/2.0)"
+TIMEOUT = 12
+WORLDCAM_LIVE_IMG_RE = re.compile(
+    r'https?://(?:www\.)?(?:img\.)?worldcam\.pl/(?:images/)?webcams/420x236/[^"\' >]+\.jpg',
+    re.I,
+)
+
+
+def fetch(url: str) -> str | None:
+    try:
+        req = request.Request(url, headers={"User-Agent": UA})
+        with request.urlopen(req, timeout=TIMEOUT) as r:
+            return r.read().decode("utf-8", errors="replace")
+    except Exception as exc:
+        LOG.debug("fetch failed %s: %s", url, exc)
+        return None
+
+
+def head_ok(url: str) -> bool:
+    try:
+        req = request.Request(url, method="HEAD", headers={"User-Agent": UA})
+        with request.urlopen(req, timeout=TIMEOUT) as r:
+            return 200 <= r.status < 300
+    except urlerror.HTTPError as exc:
+        return exc.code == 405  # treat method-not-allowed as "image exists"
+    except Exception:
+        return False
+
+
+def baltic_snapshot(cam: dict) -> str | None:
+    """Return the live thumbnail URL when it's hosted on the live CDN."""
+    thumb = cam.get("thumbnailUrl") or ""
+    if thumb.startswith("https://thumbs.balticlivecam.com/"):
+        return thumb
+    return None
+
+
+def worldcam_snapshot(cam: dict) -> str | None:
+    """Fetch the per-cam page and extract the first 420x236 JPG URL."""
+    source_url = cam.get("sourceUrl") or ""
+    if not source_url:
+        return None
+    html = fetch(source_url)
+    if not html:
+        return None
+    # The main cam's snapshot is the first 420x236 image on the page; other
+    # 420x236 references are neighbor previews further down — taking the first
+    # match gives us the right one for ~all observed cases.
+    match = WORLDCAM_LIVE_IMG_RE.search(html)
+    return match.group(0) if match else None
+
+
+def parallel(items, worker, max_workers=10):
+    out = {}
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(worker, c): c["id"] for c in items}
+        for fut in as_completed(futures):
+            cam_id = futures[fut]
+            try:
+                out[cam_id] = fut.result()
+            except Exception:
+                out[cam_id] = None
+    return out
+
+
+def run(path: Path) -> dict[str, int]:
+    raw = json.loads(path.read_text())
+    items = raw["items"]
+    by_source: dict[str, list[dict]] = {}
+    for cam in items:
+        if cam.get("snapshotUrl"):
+            continue  # already enriched in round 1
+        st = (cam.get("sourceType") or "").lower()
+        if st in ("baltic", "worldcam"):
+            by_source.setdefault(st, []).append(cam)
+
+    counters: dict[str, int] = {}
+
+    # Baltic — derive snapshot from existing thumbnailUrl, no fetch needed.
+    baltic_cams = by_source.get("baltic", [])
+    baltic_candidates = {c["id"]: baltic_snapshot(c) for c in baltic_cams}
+    baltic_candidates = {k: v for k, v in baltic_candidates.items() if v}
+    LOG.info("Baltic candidates: %d", len(baltic_candidates))
+    # HEAD-validate (some `_sm.jpg` URLs 404).
+    head_results = parallel(
+        [{"id": k, "_url": v} for k, v in baltic_candidates.items()],
+        lambda c: head_ok(c["_url"]),
+        max_workers=16,
+    )
+    for cam in baltic_cams:
+        url = baltic_candidates.get(cam["id"])
+        if url and head_results.get(cam["id"]):
+            cam["snapshotUrl"] = url
+            cam.setdefault("playbackKind", "snapshot")
+            counters["baltic"] = counters.get("baltic", 0) + 1
+
+    # WorldCam — scrape each cam page.
+    worldcam_cams = by_source.get("worldcam", [])
+    LOG.info("WorldCam scrape: %d pages", len(worldcam_cams))
+    wc_results = parallel(worldcam_cams, worldcam_snapshot, max_workers=8)
+    # HEAD-validate the discovered URLs (some scrapes return stale URLs).
+    head_targets = [{"id": k, "_url": v} for k, v in wc_results.items() if v]
+    wc_head = parallel(
+        head_targets,
+        lambda c: head_ok(c["_url"]),
+        max_workers=12,
+    )
+    for cam in worldcam_cams:
+        url = wc_results.get(cam["id"])
+        if url and wc_head.get(cam["id"]):
+            cam["snapshotUrl"] = url
+            cam.setdefault("playbackKind", "snapshot")
+            counters["worldcam"] = counters.get("worldcam", 0) + 1
+
+    # Update the enrichment meta to reflect the cumulative count.
+    meta = raw.setdefault("snapshotEnrichmentMeta", {})
+    rolling = dict(meta.get("counts", {}))
+    for src, n in counters.items():
+        rolling[src] = rolling.get(src, 0) + n
+    meta["counts"] = rolling
+    meta["total"] = sum(rolling.values())
+    path.write_text(json.dumps(raw, ensure_ascii=False, indent=2) + "\n")
+    return counters
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(levelname)s %(message)s",
+    )
+    counts = run(args.input)
+    LOG.info("Added snapshotUrl to %d more cams", sum(counts.values()))
+    for src, n in counts.items():
+        LOG.info("  %s: %d", src, n)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## PR1.7: Round 2 of in-app expansion

### 누적 결과
| 라운드 | 추가 | 누적 외부 비율 |
|---|---|---|
| 기존 | — | 62.0% (940/1515) |
| PR1.6 | 181 (HK/USGS/Panomax/Roundshot) | 50.1% |
| **PR1.7** | **168 (Baltic + WorldCam)** | **39.0%** |

현재 1,515개 중 924개(61.0%)가 인앱 재생, 591개(39.0%)만 외부 링크. 24시간 전 대비 **-349 cams**가 사이트를 떠나지 않고 본다.

### 발견

**Baltic Live Cam (71/96)** — `thumbs.balticlivecam.com/blc/*_sm.jpg` CDN이 실제 라이브 썸네일. `Cache-Control: max-age=3600` + `Last-Modified` 1시간 이내. 25개는 옛 promo bucket(`balticlivecam.com/images/`)만 있어 제외 (Last-Modified 2021).

**WorldCam (97/97)** — 각 cam 페이지가 `worldcam.pl/images/webcams/420x236/<slug>.jpg`를 인라인. slug가 페이지별로 다르고 sourceUrl 규칙으로 도출 불가 → 페이지를 한 번 스크랩해서 첫 420x236 매치를 채택. HEAD 검증 후 100% 통과.

**Clima Ao Vivo (0/69)** — react-player 컴포넌트가 JS 런타임에 스트림 URL을 주입. 정적 HTML에 어떤 URL도 노출 안 됨 → headless browser 없이 스크래핑 불가, 이번 PR에서 제외.

### Changes

- **`scripts/enrich_world_tour_v2.py`** — 신규 스크립트. PR1.6 enrich와 idempotent하게 공존(이미 `snapshotUrl`이 있는 cam은 건드리지 않음). 12-16 워커 병렬 HTTP, 12s 타임아웃, regex 추출 후 HEAD 검증.
- **`data/world_tour_cams.json`** — 168 cams 신규 `snapshotUrl` + `playbackKind: snapshot`. `snapshotEnrichmentMeta.total: 349`.
- **`js/app.js`** — `getWorldTourSnapshotRefreshMs`에 baltic(2min), worldcam(3min) 추가만. 렌더링 분기는 PR1.6 path 그대로 재사용.

### 검증
- `node --check js/app.js` 통과
- enrich 스크립트 idempotent 확인 (같은 입력 반복 실행 시 동일 출력)
- Baltic 10개 샘플 Last-Modified 확인: 4개 1시간 이내, 4개 1주 이내, 2개 정적 → live 비율 적정
- WorldCam 8개 샘플 모두 200 OK

### 향후
- Clima Ao Vivo 69개는 headless browser collector (Playwright in GHA) 가 필요. 별도 PR로 분리.
- EarthCam 58, SkylineWebcams 34는 ToS상 제외.