### PR TITLE
feat(world-tour): search-match highlight + trim mobile bottom space

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2275,9 +2275,9 @@ body.world-tour-active #pwa-install-prompt {
     flex-direction: column;
     gap: 8px;
     overflow-y: auto;
-    /* Provide a generous bottom inset so the last item isn't hidden
-     * behind the in-app browser's bottom toolbar (Naver, Kakao, etc.). */
-    padding: 0 20px max(72px, calc(20px + env(safe-area-inset-bottom)));
+    /* Just enough room for the iOS home indicator / safe area below the
+     * last list item — overly large insets created an empty band. */
+    padding: 0 20px max(24px, env(safe-area-inset-bottom));
     scrollbar-width: thin;
     scrollbar-color: rgba(52, 211, 153, 0.45) rgba(15, 23, 42, 0.72);
 }
@@ -2414,6 +2414,34 @@ body.world-tour-active #pwa-install-prompt {
     font-size: 11px;
     font-style: normal;
     font-weight: 800;
+}
+
+/* Subtitle (description) row appears only when search hits the subtitle —
+ * makes it clear WHY a row like "나이아가라 폭포" matched a query like "경"
+ * (because the subtitle reads "...실시간 풍경"). */
+.world-tour-list-item-main .world-tour-list-item-subtitle {
+    overflow: hidden;
+    color: #cbd5e1;
+    font-size: 11.5px;
+    font-style: italic;
+    font-weight: 600;
+    line-height: 1.35;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+/* Yellow-highlighter look on every part of a row that matched the search.
+ * Translucent yellow background + bold red text so it reads as a literal
+ * highlighter pass over the matching characters. */
+.world-tour-search-highlight {
+    padding: 0 2px;
+    border-radius: 3px;
+    background: rgba(250, 204, 21, 0.42);
+    color: #dc2626;
+    font-weight: 900;
+    -webkit-text-fill-color: #dc2626;
 }
 
 .world-tour-list-item-actions {
@@ -2948,11 +2976,10 @@ body.world-tour-active #pwa-install-prompt {
         gap: 10px;
         height: var(--world-tour-menu-height);
         max-height: none;
-        /* Lift the bottom menu so the last row isn't clipped behind the
-         * iOS home indicator / Android nav bar / in-app browser toolbar
-         * (Naver, KakaoTalk, Instagram). env(safe-area-inset-bottom) is
-         * unreliable inside in-app webviews, so use a generous floor. */
-        padding: 10px 10px max(72px, calc(18px + env(safe-area-inset-bottom)));
+        /* Just enough bottom inset for the iOS home indicator / browser
+         * safe area — too much was clipping the card-rail's bottom row
+         * and leaving a big empty band under the cards. */
+        padding: 10px 10px max(20px, env(safe-area-inset-bottom));
         border-right: 0;
         border-bottom: 0;
         border-left: 0;
@@ -3214,7 +3241,7 @@ body.world-tour-active #pwa-install-prompt {
 
     .world-tour-bottom-menu {
         gap: 8px;
-        padding: 8px 8px max(64px, calc(16px + env(safe-area-inset-bottom)));
+        padding: 8px 8px max(16px, env(safe-area-inset-bottom));
     }
 
     .world-tour-selected-summary {

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <link rel="dns-prefetch" href="//dapi.kakao.com">
     <link rel="dns-prefetch" href="//tile.openstreetmap.org">
-    <link rel="stylesheet" href="css/style.css?v=20260521-78623768">
+    <link rel="stylesheet" href="css/style.css?v=20260521-search-highlight">
 
     <!-- Kakao Maps -->
     <script type="text/javascript"
@@ -253,7 +253,7 @@
             summaryUrl: 'https://cctv-quality.pyw31337.workers.dev/v1/summary'
         };
     </script>
-    <script src="js/app.js?v=20260521-78623768"></script>
+    <script src="js/app.js?v=20260521-search-highlight"></script>
     <script>
         // Register the offline-friendly service worker. Wrapped in a load
         // listener so SW registration never blocks first paint; wrapped in a

--- a/js/app.js
+++ b/js/app.js
@@ -14,7 +14,7 @@ const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-78623768';
+const APP_BUILD_VERSION = '20260521-search-highlight';
 const SERVICE_BANNER_VISIBLE_MS = 5000;
 const PLAYBACK_HEALTH_STORAGE_KEY = 'cctv_playback_health_v1';
 const PLAYBACK_HEALTH_SCHEMA_VERSION = 2;
@@ -5358,28 +5358,69 @@ function renderWorldTourListSelectOptions(entries, selectedValue, allLabel) {
     return options.join('');
 }
 
+// Wraps every occurrence of `search` inside `text` with a <mark> element,
+// returning HTML-safe output. The match is case-insensitive (we lowercase
+// both haystack and needle). Use this anywhere we surface a field that
+// might be why the row was matched, so users can see WHY their query hit.
+function highlightWorldTourMatch(text, search) {
+    const raw = text == null ? '' : String(text);
+    if (!raw) return '';
+    const needle = normalizeWorldTourText(search);
+    if (!needle) return escapeWorldTourHtml(raw);
+
+    const lower = raw.toLowerCase();
+    const len = needle.length;
+    const out = [];
+    let cursor = 0;
+    while (cursor < raw.length) {
+        const idx = lower.indexOf(needle, cursor);
+        if (idx < 0) {
+            out.push(escapeWorldTourHtml(raw.slice(cursor)));
+            break;
+        }
+        if (idx > cursor) out.push(escapeWorldTourHtml(raw.slice(cursor, idx)));
+        out.push(`<mark class="world-tour-search-highlight">${escapeWorldTourHtml(raw.slice(idx, idx + len))}</mark>`);
+        cursor = idx + len;
+    }
+    return out.join('');
+}
+
 function renderWorldTourListItems(items, selectedId) {
     if (!items.length) {
         return '<div class="world-tour-list-empty">조건에 맞는 세계 CCTV가 없습니다. 검색어나 필터를 줄여보세요.</div>';
     }
 
+    const search = state.worldTourListSearch;
+
     return items.map(cam => {
         const isActive = cam.id === selectedId;
         const sourceLabel = getWorldTourSourceLabel(cam);
+        const regionLabel = getWorldTourRegionLabel(cam.region);
         const externalOnly = !canPlayWorldTourInApp(cam);
         const externalBadge = externalOnly
             ? `<span class="world-tour-external-badge" title="원본사이트에서만 재생 가능" aria-label="원본사이트에서만 재생 가능">${WORLD_TOUR_VIDEO_OFF_SVG}</span>`
+            : '';
+        // Only render the subtitle row when a search is active and the
+        // subtitle would actually help explain the match — otherwise we
+        // keep list rows compact like before.
+        const subtitle = cam.subtitle || '';
+        const subtitleMatches = search
+            && subtitle
+            && normalizeWorldTourText(subtitle).includes(normalizeWorldTourText(search));
+        const subtitleRow = subtitleMatches
+            ? `<span class="world-tour-list-item-subtitle">${highlightWorldTourMatch(subtitle, search)}</span>`
             : '';
         return `
             <article class="world-tour-list-item ${isActive ? 'active' : ''}" data-world-tour-list-item="${escapeWorldTourHtml(cam.id)}" tabindex="0">
                 ${renderWorldTourFavoriteButton(cam, 'list')}
                 <div class="world-tour-list-item-main">
                     <strong class="world-tour-list-item-title">
-                        <span class="world-tour-list-item-title-text">${escapeWorldTourHtml(cam.title)}</span>
+                        <span class="world-tour-list-item-title-text">${highlightWorldTourMatch(cam.title, search)}</span>
                         ${externalBadge}
                     </strong>
-                    <span>${escapeWorldTourHtml(cam.city)} · ${escapeWorldTourHtml(cam.country)}</span>
-                    <em>${escapeWorldTourHtml(getWorldTourRegionLabel(cam.region))} · ${escapeWorldTourHtml(sourceLabel)}</em>
+                    <span>${highlightWorldTourMatch(cam.city, search)} · ${highlightWorldTourMatch(cam.country, search)}</span>
+                    <em>${highlightWorldTourMatch(regionLabel, search)} · ${highlightWorldTourMatch(sourceLabel, search)}</em>
+                    ${subtitleRow}
                 </div>
                 <div class="world-tour-list-item-actions">
                     <button type="button" data-world-tour-list-map="${escapeWorldTourHtml(cam.id)}">지도</button>


### PR DESCRIPTION
Two changes based on the latest screenshot review.

### Why a non-title result like 나이아가라 폭포 matched 경

The world-tour search runs over multiple fields including `subtitle`. 나이아가라 폭포 has subtitle `북미 대표 폭포의 실시간 풍경` — '풍**경**' is the match. This PR makes that visible:

- `highlightWorldTourMatch(text, search)` wraps every occurrence of the query with `<mark class="world-tour-search-highlight">`, styled as a yellow-highlighter (translucent yellow background) with bold red text.
- Applied to title, city, country, region label, and source label in every list row.
- The subtitle line is rendered inline **only when the subtitle is the matching field**, so the user can see exactly which characters in the description hit.

### Trim the mobile bottom space

The previous safe-area floor of `max(72px, env+18px)` was overcompensating in browsers where `env(safe-area-inset-bottom)` is 0. Two visible symptoms in the screenshot:

1. The bottom row of cards in the card-rail (region · source — e.g. `Asia · YouTube`) was being clipped by `overflow: hidden`.
2. A large empty band sat below the cards.

Reduced to `max(20px, env(safe-area-inset-bottom))` (and `max(24px, env)` for the panel results), which is enough for the iOS home indicator without wasting space.

Build version bumped.
