### PR TITLE
fix(jindo/z3): client-side resilience for Oracle proxy outages

### DIFF
--- a/cctv_data.json
+++ b/cctv_data.json
@@ -51551,16 +51551,6 @@
   },
   {
     "backup_urls": [],
-    "id": "E901115",
-    "lat": 36.8578,
-    "lng": 127.9221,
-    "name": "[국도18호선]진도향토문화회관",
-    "source": "UTIC",
-    "status": "active",
-    "url": "https://www.utic.go.kr/jsp/map/openDataCctvStream.jsp?key=yjEgVGKAyWZGHyTy0gqNA8ZAq6IudLYWVqk8frqUI&cctvid=E901115&cctvName=%5B%EA%B5%AD%EB%8F%8418%ED%98%B8%EC%84%A0%5D%EC%A7%84%EB%8F%84%ED%96%A5%ED%86%A0%EB%AC%B8%ED%99%94%ED%9A%8C%EA%B4%80&kind=Z3&cctvip=73604&id=73604%2FTZyaRqBZxHm3rPvMBbYDvZBh6cTnxbHhhd80NOpNxhdkZwgaHpZAUkj%2FA8xLkDTw"
-  },
-  {
-    "backup_urls": [],
     "id": "E901116",
     "lat": 36.809,
     "lng": 127.7998,
@@ -51588,16 +51578,6 @@
     "source": "UTIC",
     "status": "active",
     "url": "https://www.utic.go.kr/jsp/map/openDataCctvStream.jsp?key=yjEgVGKAyWZGHyTy0gqNA8ZAq6IudLYWVqk8frqUI&cctvid=E901118&cctvName=%5B%EA%B5%AD%EB%8F%8419%5D%EA%B4%B4%EC%82%B0%EB%AC%B8%EA%B0%95%EA%B5%90%EC%B0%A8%EB%A1%9C&kind=Z3&cctvip=73661&id=73661%2FLPrLC2r53sHaDiOT%2BPAIQ6i%2FgAS%2FrfcYofmTQnKZCJ6N2486GMuRVzlNEDzhohlqEoLUDF84pLc5Aam9X%2B5b8H2ufjD7DCrd1w7J%2B0Ch2kw%3D"
-  },
-  {
-    "backup_urls": [],
-    "id": "E901119",
-    "lat": 36.753225,
-    "lng": 127.727968,
-    "name": "[국도18호선]진도터널입구",
-    "source": "UTIC",
-    "status": "active",
-    "url": "https://www.utic.go.kr/jsp/map/openDataCctvStream.jsp?key=yjEgVGKAyWZGHyTy0gqNA8ZAq6IudLYWVqk8frqUI&cctvid=E901119&cctvName=%5B%EA%B5%AD%EB%8F%8418%ED%98%B8%EC%84%A0%5D%EC%A7%84%EB%8F%84%ED%84%B0%EB%84%90%EC%9E%85%EA%B5%AC&kind=Z3&cctvip=73608&id=73608%2FmU2E%2FekSWzkt1NwUUUIKk26kfzm%2Fy4F0HOQUBRwFwIhi%2BN5oI7ArusBvdAJl2VcYigrMzoJQcMsvgPHrv6IDa0YaoARNn8Xm2ZTkWwKaV8M%3D"
   },
   {
     "backup_urls": [],

--- a/cctv_overrides.json
+++ b/cctv_overrides.json
@@ -238,13 +238,6 @@
     "_comment": "Auto-extracted from VIP logic"
   },
   {
-    "id": "E901115",
-    "name": "[국도18호선]진도향토문화회관",
-    "url": "https://www.utic.go.kr/jsp/map/openDataCctvStream.jsp?key=yjEgVGKAyWZGHyTy0gqNA8ZAq6IudLYWVqk8frqUI&cctvid=E901115&cctvName=%5B%EA%B5%AD%EB%8F%8418%ED%98%B8%EC%84%A0%5D%EC%A7%84%EB%8F%84%ED%96%A5%ED%86%A0%EB%AC%B8%ED%99%94%ED%9A%8C%EA%B4%80&kind=Z3&cctvip=73604&id=73604%2FTZyaRqBZxHm3rPvMBbYDvZBh6cTnxbHhhd80NOpNxhdkZwgaHpZAUkj%2FA8xLkDTw",
-    "tags": [],
-    "_comment": "Auto-extracted from VIP logic"
-  },
-  {
     "id": "E910993",
     "name": "[대구부산선]밀양강교",
     "url": "https://www.utic.go.kr/jsp/map/openDataCctvStream.jsp?key=yjEgVGKAyWZGHyTy0gqNA8ZAq6IudLYWVqk8frqUI&cctvid=E910993&cctvName=%5B%EB%8C%80%EA%B5%AC%EB%B6%80%EC%82%B0%EC%84%A0%5D%EC%82%BC%EB%9E%91%EC%A7%84IC&kind=Z3&cctvip=5090&id=5090%2FGwDD0ElMv3pfGnIBnQEytO6JMEmmxURIhMf4jjXBHH180pHddRoLZSI9NoONwrb3szCgnNdMilfuiWSQGxCXl5li6R7%2Bp7zqYUmecjunL3k%3D",
@@ -1592,13 +1585,6 @@
     "id": "E912479",
     "name": "[수도권제2순환선(파주양주)][양주]광적1터널(양주)-16/32",
     "url": "https://www.utic.go.kr/jsp/map/openDataCctvStream.jsp?key=yjEgVGKAyWZGHyTy0gqNA8ZAq6IudLYWVqk8frqUI&cctvid=E912479&cctvName=%255B%25EC%2588%2598%25EB%258F%2584%25EA%25B6%258C%25EC%25A0%259C2%25EC%2588%259C%25ED%2599%2598%25EC%2584%25A0%2528%25ED%258C%258C%25EC%25A3%25BC%25EC%2596%2591%25EC%25A3%25BC%2529%255D%255B%25EC%2596%2591%25EC%25A3%25BC%255D%25EA%25B4%2591%25EC%25A0%25811%25ED%2584%25B0%25EB%2584%2590%2528%25EC%2596%2591%25EC%25A3%25BC%2529-16/32&kind=Z3&cctvip=95647&cctvch=null&id=95647/EZC9nA4RBqOSZsEfQm4m7RrWYEwBmHHMXKnKMYdw8mZQG8MhCjAU42NCw80nVOlkdMNiPZ7b4Rgs91+iuqt606nifOBkFaOaBMboxQ3VAKM=&cctvpasswd=null&cctvport=null",
-    "tags": [],
-    "_comment": "Auto-extracted from VIP logic"
-  },
-  {
-    "id": "E901119",
-    "name": "[국도18호선]진도터널입구",
-    "url": "https://www.utic.go.kr/jsp/map/openDataCctvStream.jsp?key=yjEgVGKAyWZGHyTy0gqNA8ZAq6IudLYWVqk8frqUI&cctvid=E901119&cctvName=%5B%EA%B5%AD%EB%8F%8418%ED%98%B8%EC%84%A0%5D%EC%A7%84%EB%8F%84%ED%84%B0%EB%84%90%EC%9E%85%EA%B5%AC&kind=Z3&cctvip=73608&id=73608%2FmU2E%2FekSWzkt1NwUUUIKk26kfzm%2Fy4F0HOQUBRwFwIhi%2BN5oI7ArusBvdAJl2VcYigrMzoJQcMsvgPHrv6IDa0YaoARNn8Xm2ZTkWwKaV8M%3D",
     "tags": [],
     "_comment": "Auto-extracted from VIP logic"
   },

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <link rel="dns-prefetch" href="//dapi.kakao.com">
     <link rel="dns-prefetch" href="//tile.openstreetmap.org">
-    <link rel="stylesheet" href="css/style.css?v=20260521-1e4e402a">
+    <link rel="stylesheet" href="css/style.css?v=20260521-jindo-z3-resilience">
 
     <!-- Kakao Maps -->
     <script type="text/javascript"
@@ -253,7 +253,7 @@
             summaryUrl: 'https://cctv-quality.pyw31337.workers.dev/v1/summary'
         };
     </script>
-    <script src="js/app.js?v=20260521-1e4e402a"></script>
+    <script src="js/app.js?v=20260521-jindo-z3-resilience"></script>
     <script>
         // Register the offline-friendly service worker. Wrapped in a load
         // listener so SW registration never blocks first paint; wrapped in a

--- a/js/app.js
+++ b/js/app.js
@@ -14,7 +14,7 @@ const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-1e4e402a';
+const APP_BUILD_VERSION = '20260521-jindo-z3-resilience';
 const SERVICE_BANNER_VISIBLE_MS = 5000;
 const PLAYBACK_HEALTH_STORAGE_KEY = 'cctv_playback_health_v1';
 const PLAYBACK_HEALTH_SCHEMA_VERSION = 2;
@@ -290,9 +290,12 @@ async function loadZ3Cache() {
     if (z3CacheData) return z3CacheData;
     if (z3CachePromise) return z3CachePromise;
     const cacheBucket = Math.floor(Date.now() / 1800000);
+    // Static GitHub snapshot first — Oracle /z3-cache.json was hanging 12s+ in May 2026,
+    // blocking the entire Z3 playback pipeline. Static is hourly-refreshed by the GHA so
+    // freshness loss vs Oracle is at most ~30min — well within Z3_CACHE_STALE_MS (60min).
     const urls = [
-        `${ORACLE_BASE}/z3-cache.json?v=${APP_BUILD_VERSION}&t=${cacheBucket}`,
-        `data/z3_cache.json?v=${APP_BUILD_VERSION}&t=${cacheBucket}`
+        `data/z3_cache.json?v=${APP_BUILD_VERSION}&t=${cacheBucket}`,
+        `${ORACLE_BASE}/z3-cache.json?v=${APP_BUILD_VERSION}&t=${cacheBucket}`
     ];
 
     z3CachePromise = (async () => {
@@ -4140,11 +4143,13 @@ function createVideoElement(cctv, sourceIndex = 0) {
                         capLevelToPlayerSize: true,
                         maxBufferLength: 30,
                         maxMaxBufferLength: 60,
-                        fragLoadingTimeOut: isZ3 ? 16000 : 30000,
-                        manifestLoadingTimeOut: isZ3 ? 9000 : 15000,
-                        manifestLoadingMaxRetry: isZ3 ? 1 : 2,
-                        levelLoadingMaxRetry: isZ3 ? 1 : 2,
-                        fragLoadingMaxRetry: isZ3 ? 2 : 4,
+                        // Z3 매니페스트는 Oracle 프록시 경유로 RTT 변동이 큼 — 1회 재시도는 첫 패스 일시
+                        // 실패에 너무 가혹. 9s→15s, retry 1→2 로 완화해 부팅 직후 cold-start 흡수.
+                        fragLoadingTimeOut: isZ3 ? 18000 : 30000,
+                        manifestLoadingTimeOut: isZ3 ? 15000 : 15000,
+                        manifestLoadingMaxRetry: isZ3 ? 2 : 2,
+                        levelLoadingMaxRetry: isZ3 ? 2 : 2,
+                        fragLoadingMaxRetry: isZ3 ? 3 : 4,
                     });
                     hls.loadSource(streamUrl);
                     hls.attachMedia(video);

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@
 // The CACHE_VERSION is hot-swapped by the deploy GHA so a new release purges
 // all prior caches even when a long-lived tab still holds the old SW.
 
-const CACHE_VERSION = 'v20260521-1e4e402a';
+const CACHE_VERSION = 'v20260521-jindo-z3-resilience';
 const SHELL_CACHE = `cctv-shell-${CACHE_VERSION}`;
 const DATA_CACHE = `cctv-data-${CACHE_VERSION}`;
 const IMG_CACHE = `cctv-img-${CACHE_VERSION}`;


### PR DESCRIPTION
## 문제

며칠째 진도/Z3 CCTV가 "연결이 불안정합니다 / 1/3"로 첫 로딩 실패. 진단:

1. **Oracle 158.179.194.163.sslip.io 의 /z3-cache.json, /utic 가 12s+ hang** (/health-status, /proxy 는 정상). loadZ3Cache가 Oracle을 1순위로 시도 → 매번 12초 잡아먹고 HLS 매니페스트 타임아웃(9s)이 먼저 터짐.
2. **HLS Z3 옵션 과공격적**: manifestLoadingMaxRetry=1, timeout=9s. Oracle RTT 변동에 cold-start 1회 일시실패가 그대로 노출.
3. **cctv_data.json 에 진도 유령 2건**(E901115, E901119): 이름은 [국도18호선]진도... 인데 좌표가 충북(lat 36.75~36.86). 과거 ID 시프트 잔재.

## 변경

- js/app.js loadZ3Cache: 정적 GitHub 캐시를 1순위, Oracle fallback (역전)
- Z3 HLS 옵션 완화: manifest 9s→15s, manifestLoadingMaxRetry 1→2, levelLoadingMaxRetry 1→2, frag 16s→18s, fragMaxRetry 2→3
- cctv_data.json, cctv_overrides.json: E901115, E901119 제거 (남은 진도 5건 정상 좌표 확인)
- APP_BUILD_VERSION + SW CACHE_VERSION bump → 사용자 브라우저 캐시 무효화

## 추가 권장 (사용자 액션 필요)
- Oracle VM에서 /z3-cache.json, /utic 핸들러 점검 및 재시작
- 진도로 이동하려면 검색창 "진도" 입력 후 드롭다운에서 진도군 선택 필요 (현재 자동 이동 안함)
