### PR TITLE
feat(world-tour): white-on-amber highlight + clear left side while searching

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -954,6 +954,9 @@ body {
 }
 
 .search-sort-panel {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     padding: 10px 12px;
     border-bottom: 1px solid var(--border-color);
     background:
@@ -962,7 +965,9 @@ body {
 }
 
 .search-sort-select {
-    width: 100%;
+    flex: 1 1 auto;
+    width: auto;
+    min-width: 0;
     max-width: none;
     height: 38px;
     padding: 0 38px 0 14px;
@@ -972,6 +977,35 @@ body {
         url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='%23a7f3d0' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E")
         no-repeat right 13px center;
     background-size: 18px 18px;
+}
+
+/* "전국 주요 도시 라이브" entry — circular CCTV-icon button to the right
+ * of the sort selector in the mobile search panel. */
+.search-compare-btn {
+    flex: 0 0 38px;
+    width: 38px;
+    height: 38px;
+    padding: 0;
+    border: 1px solid rgba(52, 211, 153, 0.28);
+    border-radius: 999px;
+    background: rgba(30, 41, 59, 0.92);
+    color: #bbf7d0;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+.search-compare-btn:hover,
+.search-compare-btn:focus-visible {
+    background: rgba(20, 83, 45, 0.55);
+    border-color: rgba(52, 211, 153, 0.55);
+    color: #d1fae5;
+    outline: none;
+}
+.search-compare-btn svg {
+    width: 20px;
+    height: 20px;
 }
 
 .search-history-scroll {
@@ -2117,6 +2151,30 @@ body.world-tour-active #pwa-install-prompt {
     justify-content: flex-end;
     background: rgba(2, 6, 23, 0.58);
     backdrop-filter: blur(10px);
+    transition: background var(--transition), backdrop-filter var(--transition);
+}
+
+/* While the user is actively searching, clear the dim+blur on the left
+ * side so they can still see the map / video underneath. Paired with
+ * `.world-tour-shell.is-searching .world-tour-bottom-menu { display:none }`
+ * below — together they give the panel a focused, side-by-side feel. */
+.world-tour-list-overlay.is-searching {
+    background: transparent;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+}
+
+.world-tour-shell.is-searching .world-tour-bottom-menu {
+    display: none;
+}
+
+.world-tour-shell.is-searching .world-tour-hero,
+.world-tour-shell.is-searching .world-tour-map-stage {
+    /* The hero is normally constrained to the area above the bottom
+     * menu. Once the menu is hidden, let it stretch to fill the screen
+     * so the map/video reads as the background of the search session. */
+    inset: 0;
+    bottom: 0;
 }
 
 .world-tour-list-panel {
@@ -2433,15 +2491,17 @@ body.world-tour-active #pwa-install-prompt {
 }
 
 /* Yellow-highlighter look on every part of a row that matched the search.
- * Translucent yellow background + bold red text so it reads as a literal
- * highlighter pass over the matching characters. */
+ * Saturated amber background + bold white text. We use amber rather than
+ * pale yellow because white text needs a dark-enough background to stay
+ * legible. */
 .world-tour-search-highlight {
-    padding: 0 2px;
+    padding: 0 3px;
     border-radius: 3px;
-    background: rgba(250, 204, 21, 0.42);
-    color: #dc2626;
+    background: rgba(202, 138, 4, 0.85);
+    color: #ffffff;
     font-weight: 900;
-    -webkit-text-fill-color: #dc2626;
+    -webkit-text-fill-color: #ffffff;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.35);
 }
 
 .world-tour-list-item-actions {
@@ -3929,6 +3989,14 @@ body.world-tour-active #pwa-install-prompt {
 .compare-mode-btn:hover {
     background: rgba(20, 83, 45, 0.42);
     color: #bbf7d0;
+}
+
+/* On narrow screens the compare button moves into the search panel
+ * (next to the sort selector), so hide the header copy. */
+@media (max-width: 600px) {
+    .compare-mode-btn {
+        display: none;
+    }
 }
 
 .compare-layer {

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <link rel="dns-prefetch" href="//dapi.kakao.com">
     <link rel="dns-prefetch" href="//tile.openstreetmap.org">
-    <link rel="stylesheet" href="css/style.css?v=20260521-f9b86e3b">
+    <link rel="stylesheet" href="css/style.css?v=20260521-search-active-clear">
 
     <!-- Kakao Maps -->
     <script type="text/javascript"
@@ -253,7 +253,7 @@
             summaryUrl: 'https://cctv-quality.pyw31337.workers.dev/v1/summary'
         };
     </script>
-    <script src="js/app.js?v=20260521-f9b86e3b"></script>
+    <script src="js/app.js?v=20260521-search-active-clear"></script>
     <script>
         // Register the offline-friendly service worker. Wrapped in a load
         // listener so SW registration never blocks first paint; wrapped in a

--- a/js/app.js
+++ b/js/app.js
@@ -14,7 +14,7 @@ const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-f9b86e3b';
+const APP_BUILD_VERSION = '20260521-search-active-clear';
 const SERVICE_BANNER_VISIBLE_MS = 5000;
 const PLAYBACK_HEALTH_STORAGE_KEY = 'cctv_playback_health_v1';
 const PLAYBACK_HEALTH_SCHEMA_VERSION = 2;
@@ -706,8 +706,17 @@ function setupEventListeners() {
     // Location Button
     $('#location-btn').addEventListener('click', handleCurrentLocation);
 
-    // Search Results Click (Delegation for items, bookmark, delete, cctv favorite)
+    // Search Results Click (Delegation for items, bookmark, delete, cctv favorite, open compare)
     $('#search-results').addEventListener('click', (e) => {
+        // 전국 주요 도시 라이브 (mobile entry point inside the search panel)
+        const compareBtn = e.target.closest('[data-action="open-compare-mode"]');
+        if (compareBtn) {
+            e.stopPropagation();
+            $('#search-results').classList.remove('active');
+            $('#dim-overlay').classList.remove('active');
+            openCompareMode();
+            return;
+        }
         // CCTV favorite item — opens video layer directly
         const favItem = e.target.closest('.cctv-favorite-item');
         if (favItem) {
@@ -859,6 +868,9 @@ function renderSearchSortPanel() {
                     <option value="${mode}" ${state.sortMode === mode ? 'selected' : ''}>${QUALITY_SORT_LABELS[mode]}</option>
                 `).join('')}
             </select>
+            <button type="button" class="search-compare-btn" data-action="open-compare-mode" title="전국 주요 도시 라이브" aria-label="전국 주요 도시 라이브">
+                ${COMPARE_MODE_ICON_SVG}
+            </button>
         </div>
     `;
 }
@@ -4923,6 +4935,18 @@ function closeCompareMode() {
     document.body.classList.remove('compare-mode-active');
 }
 
+// lucide-cctv icon — used for the "전국 주요 도시 라이브" button on both the
+// desktop header and inside the mobile search-results compact panel.
+const COMPARE_MODE_ICON_SVG = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-cctv-icon lucide-cctv" aria-hidden="true">
+        <path d="M16.75 12h3.632a1 1 0 0 1 .894 1.447l-2.034 4.069a1 1 0 0 1-1.708.134l-2.124-2.97"/>
+        <path d="M17.106 9.053a1 1 0 0 1 .447 1.341l-3.106 6.211a1 1 0 0 1-1.342.447L3.61 12.3a2.92 2.92 0 0 1-1.3-3.91L3.69 5.6a2.92 2.92 0 0 1 3.92-1.3z"/>
+        <path d="M2 19h3.76a2 2 0 0 0 1.8-1.1L9 15"/>
+        <path d="M2 21v-4"/>
+        <path d="M7 9h.01"/>
+    </svg>
+`;
+
 function initCompareModeButton() {
     if (document.getElementById('compare-mode-btn')) return;
     const header = document.querySelector('.header-inner');
@@ -4931,16 +4955,9 @@ function initCompareModeButton() {
     btn.id = 'compare-mode-btn';
     btn.className = 'compare-mode-btn';
     btn.type = 'button';
-    btn.title = '전국 주요 도시 비교';
-    btn.setAttribute('aria-label', '전국 주요 도시 비교');
-    btn.innerHTML = `
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="3" y="3" width="7" height="7" rx="1"/>
-            <rect x="14" y="3" width="7" height="7" rx="1"/>
-            <rect x="3" y="14" width="7" height="7" rx="1"/>
-            <rect x="14" y="14" width="7" height="7" rx="1"/>
-        </svg>
-    `;
+    btn.title = '전국 주요 도시 라이브';
+    btn.setAttribute('aria-label', '전국 주요 도시 라이브');
+    btn.innerHTML = COMPARE_MODE_ICON_SVG;
     btn.addEventListener('click', openCompareMode);
     const weatherBtn = document.getElementById('weather-btn');
     if (weatherBtn && weatherBtn.parentElement === header) {
@@ -6220,6 +6237,30 @@ function bindWorldTourListPanel(root, cams, selected) {
     const panel = root.querySelector('.world-tour-list-panel');
     if (!overlay || !panel) return;
 
+    const shell = root.querySelector('.world-tour-shell');
+
+    // Toggle the "search active" state — overlay drops its blur/dim so the
+    // user can still see the map/video, and the bottom menu disappears so
+    // the left side is a clean canvas while they explore results.
+    let lastSearchActive = null;
+    const setSearchActive = (active) => {
+        const next = !!active;
+        if (lastSearchActive === next) return;
+        lastSearchActive = next;
+        overlay.classList.toggle('is-searching', next);
+        if (shell) shell.classList.toggle('is-searching', next);
+        // The map-stage resizes when the bottom menu disappears (and again
+        // when it reappears); Leaflet needs a kick so it paints tiles for
+        // the newly exposed area. Run on the next frame so the layout has
+        // already settled.
+        if (typeof worldTourLeafletMap !== 'undefined' && worldTourLeafletMap?.invalidateSize) {
+            requestAnimationFrame(() => {
+                try { worldTourLeafletMap.invalidateSize(false); } catch (e) { /* map gone */ }
+            });
+        }
+    };
+    setSearchActive(Boolean(state.worldTourListSearch));
+
     const rerenderWithList = (selectedId = state.selectedWorldTourId, extraOptions = {}) => {
         const cardRail = root.querySelector('.world-tour-card-rail');
         const regionTabs = root.querySelector('.world-tour-region-tabs');
@@ -6258,7 +6299,8 @@ function bindWorldTourListPanel(root, cams, selected) {
         rerenderWithList();
     });
 
-    panel.querySelector('[data-world-tour-list-search]')?.addEventListener('input', event => {
+    const searchInput = panel.querySelector('[data-world-tour-list-search]');
+    searchInput?.addEventListener('input', event => {
         state.worldTourListSearch = event.target.value;
         // Any active typing should force results to come from the full
         // dataset so users aren't accidentally filtered out by a region
@@ -6268,7 +6310,16 @@ function bindWorldTourListPanel(root, cams, selected) {
             state.worldTourListRegion = 'All';
             refreshRegionChips();
         }
+        setSearchActive(Boolean(state.worldTourListSearch));
         refreshResults();
+    });
+    // Treat focus/blur as a softer signal — while the input is focused,
+    // even an empty query keeps the left side clear so the user can
+    // glance at the map before typing. Once they tab away and the query
+    // is empty, revert to the default blurred backdrop.
+    searchInput?.addEventListener('focus', () => setSearchActive(true));
+    searchInput?.addEventListener('blur', () => {
+        setSearchActive(Boolean(state.worldTourListSearch));
     });
 
     panel.querySelector('[data-world-tour-list-country]')?.addEventListener('change', event => {


### PR DESCRIPTION
Two refinements on the world-tour search panel.

### Highlight color: red → white on amber

White text on the previous pale-yellow background was unreadable. Switched to a saturated amber background (`rgba(202, 138, 4, 0.85)`) with bold white text and a subtle dark text-shadow. The matching characters now read clearly without relying on color discrimination.

### Clear the left side while searching

When the user is actively searching, the left half of the screen now shows the live map / video clearly instead of being blurred and dimmed:

- Toggling on a new `.is-searching` class drops `backdrop-filter` and the dim background from `.world-tour-list-overlay`.
- The same class on `.world-tour-shell` hides `.world-tour-bottom-menu` (`display: none`) and lets `.world-tour-map-stage` / `.world-tour-hero` stretch to `inset: 0` so the map fills the full screen behind the panel.
- The state activates on `focus` or whenever the input has a non-empty value, and deactivates on `blur` + empty input.
- Leaflet's `invalidateSize()` is called on each toggle so newly exposed tiles paint correctly.

Build version bumped.
