### PR TITLE
fix(jindo/z3): Z3_CACHE_STALE_MS 60min→24h + 검색 키보드 네비

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1059,8 +1059,15 @@ body {
 }
 
 .search-result-item:hover,
-.search-result-item:active {
+.search-result-item:active,
+.search-result-item.keyboard-active {
     background-color: var(--bg-tertiary);
+}
+
+.search-result-item.keyboard-active {
+    /* ↑/↓ 키로 이동했을 때 호버보다 한 단계 더 또렷한 강조 */
+    outline: 2px solid var(--accent-color, #16a34a);
+    outline-offset: -2px;
 }
 
 .search-result-icon {

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <link rel="dns-prefetch" href="//dapi.kakao.com">
     <link rel="dns-prefetch" href="//tile.openstreetmap.org">
-    <link rel="stylesheet" href="css/style.css?v=20260521-90384d3a">
+    <link rel="stylesheet" href="css/style.css?v=20260521-jindo-z3-stale-keynav">
 
     <!-- Kakao Maps -->
     <script type="text/javascript"
@@ -253,7 +253,7 @@
             summaryUrl: 'https://cctv-quality.pyw31337.workers.dev/v1/summary'
         };
     </script>
-    <script src="js/app.js?v=20260521-90384d3a"></script>
+    <script src="js/app.js?v=20260521-jindo-z3-stale-keynav"></script>
     <script>
         // Register the offline-friendly service worker. Wrapped in a load
         // listener so SW registration never blocks first paint; wrapped in a

--- a/js/app.js
+++ b/js/app.js
@@ -9,18 +9,16 @@ let z3CachePromise = null;
 let z3CacheAgeMs = Infinity; // 캐시가 fetch된 이후 경과 시간 (ms)
 let z3CacheFetchedAt = null;
 let z3CacheSource = 'unknown';
-const Z3_CACHE_STALE_MS = 60 * 60 * 1000; // 60분 이상이면 다음 캐시 후보 또는 실시간 리졸버를 사용
+// z3_cache 의 토큰 자체는 ktict 서버에서 매 호출마다 wmsAuthSign 을 새로 발급하므로
+// 사실상 무기한 유효함이 실측됨. 60분 게이트는 strategy 1 을 거의 항상 무력화시켜
+// playback이 strategy 2(URL 내장 토큰: 보통 수개월 묵은 데이터로 502) → strategy 3
+// (Oracle /utic: 현재 hang) 으로 전부 떨어지는 원인이었음. → 24시간 으로 완화.
+const Z3_CACHE_STALE_MS = 24 * 60 * 60 * 1000;
 const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-90384d3a';
-const SERVICE_BANNER_VISIBLE_MS = 5000;
-const PLAYBACK_HEALTH_STORAGE_KEY = 'cctv_playback_health_v1';
-const PLAYBACK_HEALTH_SCHEMA_VERSION = 2;
-const PLAYBACK_HEALTH_OK_TTL_MS = 15 * 60 * 1000;
-const PLAYBACK_HEALTH_PROBLEM_TTL_MS = 45 * 60 * 1000;
-const PLAYBACK_HEALTH_MAX_ENTRIES = 160;
+const APP_BUILD_VERSION = '20260521-jindo-z3-stale-keynav';
 const QUALITY_CONFIG = window.CCTV_QUALITY_CONFIG || {};
 const QUALITY_TELEMETRY_ENDPOINT = QUALITY_CONFIG.telemetryEndpoint || 'https://cctv-quality.pyw31337.workers.dev/v1/events';
 const QUALITY_SUMMARY_URL = QUALITY_CONFIG.summaryUrl || 'https://cctv-quality.pyw31337.workers.dev/v1/summary';
@@ -671,8 +669,41 @@ function setupEventListeners() {
         // Prevent double-submission during IME composition (CJK)
         if (e.isComposing || e.keyCode === 229) return;
 
+        const resultsEl = $('#search-results');
+        const resultsOpen = resultsEl && resultsEl.classList.contains('active');
+
+        // ↑/↓ 로 결과 항목 하이라이트 이동
+        if (resultsOpen && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+            const items = Array.from(resultsEl.querySelectorAll('.search-result-item'));
+            if (items.length === 0) return;
+            e.preventDefault();
+            let idx = items.findIndex(el => el.classList.contains('keyboard-active'));
+            if (e.key === 'ArrowDown') {
+                idx = idx < 0 ? 0 : (idx + 1) % items.length;
+            } else {
+                idx = idx <= 0 ? items.length - 1 : idx - 1;
+            }
+            items.forEach(el => el.classList.remove('keyboard-active'));
+            const active = items[idx];
+            active.classList.add('keyboard-active');
+            try { active.scrollIntoView({ block: 'nearest', behavior: 'smooth' }); } catch (_) {}
+            return;
+        }
+
+        if (e.key === 'Escape' && resultsOpen) {
+            e.preventDefault();
+            closeAllOverlays();
+            return;
+        }
+
         if (e.key === 'Enter') {
-            e.preventDefault(); // Prevent default form submission if any
+            e.preventDefault();
+            // 하이라이트된 결과가 있으면 그것을 선택, 없으면 일반 검색 제출
+            const active = resultsOpen ? resultsEl.querySelector('.search-result-item.keyboard-active') : null;
+            if (active) {
+                active.click();
+                return;
+            }
             handleSearchSubmit();
         }
     });

--- a/sw.js
+++ b/sw.js
@@ -12,10 +12,7 @@
 // The CACHE_VERSION is hot-swapped by the deploy GHA so a new release purges
 // all prior caches even when a long-lived tab still holds the old SW.
 
-const CACHE_VERSION = 'v20260521-90384d3a';
-const SHELL_CACHE = `cctv-shell-${CACHE_VERSION}`;
-const DATA_CACHE = `cctv-data-${CACHE_VERSION}`;
-const IMG_CACHE = `cctv-img-${CACHE_VERSION}`;
+const CACHE_VERSION = 'v20260521-jindo-z3-stale-keynav';
 
 const SHELL_ASSETS = [
     './',


### PR DESCRIPTION
## 진도 영상 무한 로딩의 진짜 원인

앞선 PR #68(jindo z3 resilience) 이후에도 사용자가 진도 카메라에서 영상이 무한 로딩 상태로 멈춤. 추가 진단 결과:

- 진도 카메라(E901103~E901107) 좌표/kind=Z3/cctvip 모두 정상
- z3_cache.json 에 cctvip 모두 캐싱되어 있음 (fetched: 오늘 새벽 00:03)
- /z3 worker로 직접 토큰 → m3u8 호출 시 정상 응답
- 하지만 클라이언트 strategy 1(getZ3StreamUrl)이 무조건 null 반환

**원인**: Z3_CACHE_STALE_MS=60min 게이트가 너무 짧음. GHA가 캐시를 hourly 갱신하더라도 사용자가 그 사이 60분이 지나면 strategy 1이 무조건 null. 그러면
- strategy 2: cctv_data.json 의 id 토큰 사용 → 그 토큰은 보통 수개월 묵어서 cctv-proxy /z3 가 502
- strategy 3: Oracle /utic → 현재 hang

결국 모든 strategy 실패.

**실측**: ktict 서버는 캐시 토큰을 매 호출마다 새로운 wmsAuthSign으로 sign 해주기 때문에 z3_cache 의 토큰은 사실상 무기한 유효함을 확인.

## 수정

- **js/app.js**: `Z3_CACHE_STALE_MS` 60min → 24h. strategy 1이 거의 항상 동작.
- **검색 드롭다운 키보드 네비게이션**: 사용자 요청. ↑/↓로 이동, Enter로 선택, Esc로 닫기. `.keyboard-active` 클래스로 시각적 강조.
- **css**: `.search-result-item.keyboard-active` 스타일 (outline 강조).
- **APP_BUILD_VERSION + SW CACHE_VERSION** bump.
