### PR TITLE
fix(ui): 2x2 mobile grid + unified favorites + compare button in search panel (PR4)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2918,56 +2918,6 @@ body.world-tour-active #pwa-install-prompt {
         grid-template-rows: repeat(4, 1fr);
     }
 
-    /* === Mobile 1+3 layout (1 large top + 3 thumbs in horizontal scroll) === */
-    .video-grid.video-grid-mobile-1plus3 {
-        display: grid;
-        grid-template-columns: 100%;
-        grid-template-rows: minmax(0, 1fr) auto;
-        gap: 4px;
-        padding: 4px;
-    }
-
-    .video-grid.video-grid-mobile-1plus3 .video-panel[data-slot="0"] {
-        min-height: 0;
-        min-width: 0;
-    }
-
-    .video-grid.video-grid-mobile-1plus3 .video-thumb-strip {
-        display: flex;
-        flex-direction: row;
-        gap: 6px;
-        flex: 0 0 28vh;
-        max-height: 28vh;
-        min-height: 110px;
-        overflow-x: auto;
-        overflow-y: hidden;
-        scroll-snap-type: x mandatory;
-        -webkit-overflow-scrolling: touch;
-        padding-bottom: 2px;
-        scrollbar-width: thin;
-    }
-
-    .video-grid.video-grid-mobile-1plus3 .video-thumb-strip > .video-panel {
-        flex: 0 0 70%;
-        min-width: 70%;
-        scroll-snap-align: start;
-        border-radius: var(--radius-sm);
-        position: relative;
-    }
-
-    /* Compact the controls on thumbnail tiles so the small label still reads. */
-    .video-grid.video-grid-mobile-1plus3 .video-thumb-strip .cctv-select-trigger {
-        font-size: 11px;
-        padding: 6px 8px;
-        max-width: 78%;
-    }
-
-    .video-grid.video-grid-mobile-1plus3 .video-thumb-strip .panel-health-badge {
-        min-height: 24px;
-        padding: 4px 7px;
-        font-size: 10px;
-    }
-
     /* Adjust controls for mobile in grid */
     .panel-controls {
         top: 6px;
@@ -3783,6 +3733,9 @@ body.world-tour-active #pwa-install-prompt {
 }
 
 .try-another-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     border: none;
     padding: 11px 18px;
     border-radius: var(--radius-full);
@@ -3793,6 +3746,12 @@ body.world-tour-active #pwa-install-prompt {
     background: rgba(34, 197, 94, 0.18);
     color: #bbf7d0;
     border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
+.try-another-btn .try-another-icon {
+    flex: 0 0 auto;
+    width: 16px;
+    height: 16px;
 }
 
 .try-another-btn:hover {
@@ -4154,3 +4113,24 @@ body.world-tour-active #pwa-install-prompt {
     .compare-layer-header h2 { font-size: 15px; }
     .compare-layer-header p { font-size: 11px; }
 }
+
+.search-section-count {
+    margin-left: auto;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: rgba(34, 197, 94, 0.18);
+    color: #86efac;
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+}
+.cctv-favorite-item--world .source-dot {
+    background: linear-gradient(135deg, #34d399, #38bdf8);
+}
+
+
+/* PR4 hide compare-mode-btn on mobile — entry moves into the search panel */
+@media (max-width: 600px) {
+    .compare-mode-btn { display: none !important; }
+}
+

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <link rel="dns-prefetch" href="//dapi.kakao.com">
     <link rel="dns-prefetch" href="//tile.openstreetmap.org">
-    <link rel="stylesheet" href="css/style.css?v=20260521-aaabe56b">
+    <link rel="stylesheet" href="css/style.css?v=20260521-pr4-unified-favorites">
 
     <!-- Kakao Maps -->
     <script type="text/javascript"
@@ -253,7 +253,7 @@
             summaryUrl: 'https://cctv-quality.pyw31337.workers.dev/v1/summary'
         };
     </script>
-    <script src="js/app.js?v=20260521-aaabe56b"></script>
+    <script src="js/app.js?v=20260521-pr4-unified-favorites"></script>
     <script>
         // Register the offline-friendly service worker. Wrapped in a load
         // listener so SW registration never blocks first paint; wrapped in a

--- a/js/app.js
+++ b/js/app.js
@@ -18,7 +18,7 @@ const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-aaabe56b';
+const APP_BUILD_VERSION = '20260521-pr4-unified-favorites';
 const QUALITY_CONFIG = window.CCTV_QUALITY_CONFIG || {};
 const QUALITY_TELEMETRY_ENDPOINT = QUALITY_CONFIG.telemetryEndpoint || 'https://cctv-quality.pyw31337.workers.dev/v1/events';
 const QUALITY_SUMMARY_URL = QUALITY_CONFIG.summaryUrl || 'https://cctv-quality.pyw31337.workers.dev/v1/summary';
@@ -3179,47 +3179,15 @@ function updateNearestCctvs() {
     state.nearestCctvs = ordered.slice(0, NEAREST_RESULT_LIMIT);
 }
 
-// Restructures #video-grid into a 1-big + 3-thumb layout on narrow screens.
-// Wraps slots 1-3 in a horizontal-scroll strip so users can swipe between them.
-function applyMobileVideoGridLayout() {
-    const grid = document.getElementById('video-grid');
-    if (!grid) return;
-    const isNarrow = window.matchMedia('(max-width: 600px)').matches;
-    const existingStrip = grid.querySelector(':scope > .video-thumb-strip');
-
-    if (isNarrow) {
-        if (existingStrip) return; // already wrapped
-        const strip = document.createElement('div');
-        strip.className = 'video-thumb-strip';
-        const thumbs = Array.from(grid.querySelectorAll(':scope > .video-panel'))
-            .filter(panel => panel.dataset.slot !== '0');
-        thumbs.forEach(thumb => strip.appendChild(thumb));
-        grid.appendChild(strip);
-        grid.classList.add('video-grid-mobile-1plus3');
-    } else if (existingStrip) {
-        Array.from(existingStrip.children).forEach(child => grid.appendChild(child));
-        existingStrip.remove();
-        grid.classList.remove('video-grid-mobile-1plus3');
-    }
-}
-
-let _mobileGridResizeBound = false;
-function bindMobileVideoGridResponsiveness() {
-    if (_mobileGridResizeBound) return;
-    _mobileGridResizeBound = true;
-    const handler = () => applyMobileVideoGridLayout();
-    if (window.matchMedia) {
-        try { window.matchMedia('(max-width: 600px)').addEventListener('change', handler); }
-        catch (_) { window.addEventListener('resize', handler); }
-    } else {
-        window.addEventListener('resize', handler);
-    }
-}
-
+// (Mobile 1+3 layout removed by user request — keep simple 2×2 / 1×4 grid.)
 function renderVideoGrid() {
     const grid = $('#video-grid');
-    applyMobileVideoGridLayout();
-    bindMobileVideoGridResponsiveness();
+    const strayStrip = grid.querySelector(':scope > .video-thumb-strip');
+    if (strayStrip) {
+        Array.from(strayStrip.children).forEach(child => grid.appendChild(child));
+        strayStrip.remove();
+        grid.classList.remove('video-grid-mobile-1plus3');
+    }
     const panels = grid.querySelectorAll('.video-panel');
     const visiblePanelCount = panels.length;
 
@@ -5446,122 +5414,94 @@ function isWorldTourRegionAvailable(region) {
     return region === WORLD_TOUR_FAVORITE_REGION || WORLD_TOUR_REGIONS.includes(region);
 }
 
-function hydrateWorldTourFavorites() {
+// === Unified favorites store ===========================================
+const UNIFIED_FAVORITES_STORAGE_KEY = 'cctv_favorites_unified_v1';
+function hydrateUnifiedFavorites() {
     try {
-        const raw = localStorage.getItem(WORLD_TOUR_FAVORITES_STORAGE_KEY);
-        const favoriteIds = raw ? JSON.parse(raw) : [];
-        state.worldTourFavorites = new Set(Array.isArray(favoriteIds) ? favoriteIds.map(String).filter(Boolean) : []);
+        const raw = localStorage.getItem(UNIFIED_FAVORITES_STORAGE_KEY);
+        const ids = raw ? JSON.parse(raw) : [];
+        state.unifiedFavorites = new Set(Array.isArray(ids) ? ids.map(String).filter(Boolean) : []);
     } catch (error) {
-        console.warn('[WorldTour] failed to restore favorites:', error);
-        state.worldTourFavorites = new Set();
+        console.warn('[Favorites] failed to restore:', error);
+        state.unifiedFavorites = new Set();
     }
+    let migrated = false;
+    [WORLD_TOUR_FAVORITES_STORAGE_KEY, CCTV_FAVORITES_STORAGE_KEY].forEach(legacyKey => {
+        try {
+            const raw = localStorage.getItem(legacyKey);
+            if (!raw) return;
+            const ids = JSON.parse(raw);
+            if (Array.isArray(ids)) {
+                ids.map(String).filter(Boolean).forEach(id => state.unifiedFavorites.add(id));
+                localStorage.removeItem(legacyKey);
+                migrated = true;
+            }
+        } catch (_) {}
+    });
+    if (migrated) persistUnifiedFavorites();
+    state.worldTourFavorites = state.unifiedFavorites;
+    state.cctvFavorites = state.unifiedFavorites;
 }
-
-function getWorldTourFavoriteIds() {
-    if (!(state.worldTourFavorites instanceof Set)) {
-        hydrateWorldTourFavorites();
-    }
-    return state.worldTourFavorites;
+function getUnifiedFavoriteIds() {
+    if (!(state.unifiedFavorites instanceof Set)) hydrateUnifiedFavorites();
+    return state.unifiedFavorites;
 }
-
-function persistWorldTourFavorites() {
-    try {
-        const favoriteIds = [...getWorldTourFavoriteIds()];
-        localStorage.setItem(WORLD_TOUR_FAVORITES_STORAGE_KEY, JSON.stringify(favoriteIds));
-    } catch (error) {
-        console.warn('[WorldTour] failed to save favorites:', error);
-    }
+function persistUnifiedFavorites() {
+    try { localStorage.setItem(UNIFIED_FAVORITES_STORAGE_KEY, JSON.stringify([...getUnifiedFavoriteIds()])); }
+    catch (e) { console.warn('[Favorites] save failed:', e); }
 }
+function isUnifiedFavorite(o) {
+    const id = typeof o === 'object' ? o?.id : o;
+    return Boolean(id && getUnifiedFavoriteIds().has(String(id)));
+}
+function toggleUnifiedFavorite(o) {
+    const id = typeof o === 'object' ? o?.id : o;
+    if (!id) return false;
+    const f = getUnifiedFavoriteIds(); const k = String(id);
+    const will = !f.has(k);
+    if (will) f.add(k); else f.delete(k);
+    persistUnifiedFavorites();
+    return will;
+}
+function hydrateWorldTourFavorites() { hydrateUnifiedFavorites(); }
+function hydrateCctvFavorites() { hydrateUnifiedFavorites(); }
+function getWorldTourFavoriteIds() { return getUnifiedFavoriteIds(); }
+function getCctvFavoriteIds() { return getUnifiedFavoriteIds(); }
+function persistWorldTourFavorites() { persistUnifiedFavorites(); }
+function persistCctvFavorites() { persistUnifiedFavorites(); }
+function isWorldTourFavorite(o) { return isUnifiedFavorite(o); }
+function isCctvFavorite(o) { return isUnifiedFavorite(o); }
+function toggleWorldTourFavorite(id) { return toggleUnifiedFavorite(id); }
+function toggleCctvFavorite(o) { return toggleUnifiedFavorite(o); }
 
 function pruneWorldTourFavorites(cams) {
-    const favorites = getWorldTourFavoriteIds();
-    if (!favorites.size) return;
-
-    const availableIds = new Set(cams.map(cam => String(cam.id)));
+    const f = getUnifiedFavoriteIds();
+    if (!f.size) return;
+    const camIds = new Set(cams.map(c => String(c.id)));
+    const wtPrefix = /^(?:earthcam|baltic|skyline|hktraffic|usgsvolcano|panomax|roundshot|worldcam|webcamtaxi|youtube|external|africam|alertcalifornia|aurorainfo|bergfex|camscape|cctvworld|climaaovivo|dctraffic|explore|feratel|gigaeyes|hdontap|idokep|japanwebcams|liveworldwebcams|livecamcroatia|livebeaches|nswtraffic|openwebcamdb|panoramask|ptztv|publictraffic|railcam|spacecam|surfline|tabi|twlivecam|viewsurf|weatherbug|webcamhopper|webcamera24|webcamsdemexico|wetter|whatsupcams|windy|worldcamtv|worldcamlive)/i;
     let changed = false;
-    favorites.forEach(id => {
-        if (!availableIds.has(id)) {
-            favorites.delete(id);
-            changed = true;
-        }
-    });
-    if (changed) persistWorldTourFavorites();
-}
-
-function isWorldTourFavorite(camOrId) {
-    const id = typeof camOrId === 'object' ? camOrId?.id : camOrId;
-    return Boolean(id && getWorldTourFavoriteIds().has(String(id)));
-}
-
-function toggleWorldTourFavorite(camId) {
-    if (!camId) return false;
-    const favorites = getWorldTourFavoriteIds();
-    const id = String(camId);
-    const willActivate = !favorites.has(id);
-    if (willActivate) {
-        favorites.add(id);
-    } else {
-        favorites.delete(id);
-    }
-    persistWorldTourFavorites();
-    return willActivate;
-}
-
-// === General CCTV favorites (출근길 카메라 등) ===
-function hydrateCctvFavorites() {
-    try {
-        const raw = localStorage.getItem(CCTV_FAVORITES_STORAGE_KEY);
-        const ids = raw ? JSON.parse(raw) : [];
-        state.cctvFavorites = new Set(Array.isArray(ids) ? ids.map(String).filter(Boolean) : []);
-    } catch (error) {
-        console.warn('[CCTV] failed to restore favorites:', error);
-        state.cctvFavorites = new Set();
-    }
-}
-
-function getCctvFavoriteIds() {
-    if (!(state.cctvFavorites instanceof Set)) hydrateCctvFavorites();
-    return state.cctvFavorites;
-}
-
-function persistCctvFavorites() {
-    try {
-        localStorage.setItem(CCTV_FAVORITES_STORAGE_KEY, JSON.stringify([...getCctvFavoriteIds()]));
-    } catch (error) {
-        console.warn('[CCTV] failed to save favorites:', error);
-    }
-}
-
-function isCctvFavorite(cctvOrId) {
-    const id = typeof cctvOrId === 'object' ? cctvOrId?.id : cctvOrId;
-    return Boolean(id && getCctvFavoriteIds().has(String(id)));
-}
-
-function toggleCctvFavorite(cctvOrId) {
-    const id = typeof cctvOrId === 'object' ? cctvOrId?.id : cctvOrId;
-    if (!id) return false;
-    const favorites = getCctvFavoriteIds();
-    const key = String(id);
-    const willActivate = !favorites.has(key);
-    if (willActivate) favorites.add(key); else favorites.delete(key);
-    persistCctvFavorites();
-    return willActivate;
+    f.forEach(id => { if (wtPrefix.test(id) && !camIds.has(id)) { f.delete(id); changed = true; } });
+    if (changed) persistUnifiedFavorites();
 }
 
 function getFavoriteCctvs() {
-    const favorites = getCctvFavoriteIds();
-    if (!favorites.size) return [];
-    const result = [];
-    favorites.forEach(id => {
-        const found = findCctvById(id);
-        if (found) result.push(found);
-    });
-    return result;
+    const f = getUnifiedFavoriteIds();
+    if (!f.size) return [];
+    const r = [];
+    f.forEach(id => { const c = findCctvById(id); if (c) r.push(c); });
+    return r;
+}
+function getFavoriteWorldTourCams() {
+    const f = getUnifiedFavoriteIds();
+    if (!f.size) return [];
+    const cams = (state.worldTourCams && state.worldTourCams.items) || (Array.isArray(state.worldTourCams) ? state.worldTourCams : []);
+    if (!Array.isArray(cams)) return [];
+    return cams.filter(c => f.has(String(c.id)));
 }
 
 function renderCctvFavoriteButton(cctv) {
     const active = isCctvFavorite(cctv);
-    const title = active ? '즐겨찾기 해제' : '출근길 즐겨찾기에 추가';
+    const title = active ? '즐겨찾기 해제' : '즐겨찾기 추가';
     return `
         <button id="video-layer-favorite" class="layer-action-btn favorite-toggle ${active ? 'active' : ''}" title="${title}" aria-pressed="${active}" aria-label="${title}">
             <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="${active ? 'currentColor' : 'none'}" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -5569,6 +5509,7 @@ function renderCctvFavoriteButton(cctv) {
             </svg>
         </button>`;
 }
+
 
 function renderWorldTourFavoriteButton(cam, variant = 'card') {
     const isActive = isWorldTourFavorite(cam);
@@ -6957,7 +6898,7 @@ function openVideoLayer(cctv) {
         const active = isCctvFavorite(displayCctv);
         favoriteBtn.classList.toggle('active', active);
         favoriteBtn.setAttribute('aria-pressed', active ? 'true' : 'false');
-        const title = active ? '즐겨찾기 해제' : '출근길 즐겨찾기에 추가';
+        const title = active ? '즐겨찾기 해제' : '즐겨찾기 추가';
         favoriteBtn.title = title;
         favoriteBtn.setAttribute('aria-label', title);
         const svg = favoriteBtn.querySelector('svg');
@@ -6968,7 +6909,7 @@ function openVideoLayer(cctv) {
         const nowActive = toggleCctvFavorite(displayCctv);
         favoriteBtn.classList.toggle('active', nowActive);
         favoriteBtn.setAttribute('aria-pressed', nowActive ? 'true' : 'false');
-        const t = nowActive ? '즐겨찾기 해제' : '출근길 즐겨찾기에 추가';
+        const t = nowActive ? '즐겨찾기 해제' : '즐겨찾기 추가';
         favoriteBtn.title = t;
         favoriteBtn.setAttribute('aria-label', t);
         const svg = favoriteBtn.querySelector('svg');

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@
 // The CACHE_VERSION is hot-swapped by the deploy GHA so a new release purges
 // all prior caches even when a long-lived tab still holds the old SW.
 
-const CACHE_VERSION = 'v20260521-aaabe56b';
+const CACHE_VERSION = 'v20260521-pr4-unified-favorites';
 
 const SHELL_ASSETS = [
     './',


### PR DESCRIPTION
## PR4 — 사용자 요청 4가지

### 1. 모바일 4분할 원복
PR1에서 추가한 1+3 thumb-strip 레이아웃 제거 → 원래대로 모바일도 4개 영상이 동시에 보이는 vertical 4-split.

### 2. 비교 버튼 모바일 재배치 + lucide-cctv 아이콘
- 데스크탑: 헤더의 grid-rect 아이콘 → **lucide-cctv 아이콘** 으로 교체
- 모바일: 헤더 버튼 `display:none`, 검색 결과 상단의 추천순 셀렉트 박스 우측에 원형 CCTV-아이콘 버튼 추가 (`.search-compare-btn`)
- 동작: 클릭 시 검색 패널 닫고 `openCompareMode()` 호출

### 3. CCTV 즐겨찾기 + WorldTour 즐겨찾기 통합
- 새 storage key `cctv_favorites_unified_v1`
- `hydrateUnifiedFavorites()` 가 첫 실행 시 `cctv_favorites_v1` / `cctv_world_tour_favorites_v1` 자동 마이그레이션 (이전 키는 제거)
- 기존 `isCctvFavorite`, `toggleCctvFavorite`, `isWorldTourFavorite`, `toggleWorldTourFavorite` 는 모두 `*Unified` 함수에 위임하는 wrapper로 유지 → 호출부 변경 없음
- `pruneWorldTourFavorites` 는 world-tour id 패턴만 prune 하도록 수정 → 도메스틱 CCTV 즐겨찾기가 cam 리스트 갱신 시 사라지지 않음
- 검색 드롭다운에 **"즐겨찾기 · Favorite"** 헤더 + 카운트 배지 + 별 아이콘으로 통합 표시 (도메스틱+해외 같이 노출)
- WorldTour 즐겨찾기 클릭 시 `openWeather("world-tour")` 로 진입하며 해당 cam 선택 상태로 옮김
- 비디오 레이어 별 버튼 툴팁 "출근길 즐겨찾기에 추가" → "즐겨찾기 추가" 로 일반화

### 4. 빌드 버전 bump
`APP_BUILD_VERSION` + `sw.js` `CACHE_VERSION` + `index.html` `?v=...` 모두 `20260521-pr4-unified-favorites`.

### 검증
- `node --check js/app.js` 통과
- 4 files / +200 / -240