### PR TITLE
feat(ui): 북마크↔즐겨찾기 통합 + 원본만 보기 토글을 칩 카운트에 동기화 (PR5)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -18,7 +18,7 @@ const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-2eafdfb7';
+const APP_BUILD_VERSION = '20260521-pr5-unified-favorites';
 const QUALITY_CONFIG = window.CCTV_QUALITY_CONFIG || {};
 const QUALITY_TELEMETRY_ENDPOINT = QUALITY_CONFIG.telemetryEndpoint || 'https://cctv-quality.pyw31337.workers.dev/v1/events';
 const QUALITY_SUMMARY_URL = QUALITY_CONFIG.summaryUrl || 'https://cctv-quality.pyw31337.workers.dev/v1/summary';
@@ -922,37 +922,33 @@ function showSearchHistory() {
     let html = '';
     if (compactPanel) {
         html += renderSearchSortPanel();
-        html += '<div class="search-history-scroll" aria-label="북마크 및 최근 검색">';
+        html += '<div class="search-history-scroll" aria-label="즐겨찾기 및 최근 검색">';
     }
 
-    // Unified favorites — domestic CCTV + World Tour cams together
+    // Unified favorites — places (formerly 북마크) + domestic CCTV + World Tour cams.
+    // Single section, star icon, no more separate "북마크" terminology.
     const favoriteCctvs = getFavoriteCctvs();
     const favoriteWorldCams = getFavoriteWorldTourCams();
-    const totalFavorites = favoriteCctvs.length + favoriteWorldCams.length;
+    const totalFavorites = bookmarks.length + favoriteCctvs.length + favoriteWorldCams.length;
+    const STAR_SVG = '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>';
+    html += `<div class="search-section-title">
+        ${STAR_SVG}
+        <span>즐겨찾기 · Favorite</span>
+        ${totalFavorites > 0 ? `<span class="search-section-count">${totalFavorites}</span>` : ''}
+    </div>`;
     if (totalFavorites > 0) {
-        const cap = compactPanel ? SEARCH_HISTORY_PANEL_ITEM_LIMIT : 12;
-        const cappedCctvs = favoriteCctvs.slice(0, cap);
-        const remainingForWorld = Math.max(cap - cappedCctvs.length, 0);
-        const cappedWorld = favoriteWorldCams.slice(0, remainingForWorld);
-        html += `<div class="search-section-title">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-            <span>즐겨찾기 · Favorite</span>
-            <span class="search-section-count">${totalFavorites}</span>
-        </div>`;
+        const cap = compactPanel ? SEARCH_HISTORY_PANEL_ITEM_LIMIT : 24;
+        let remaining = cap;
+        const cappedBookmarks = bookmarks.slice(0, remaining); remaining -= cappedBookmarks.length;
+        const cappedCctvs = favoriteCctvs.slice(0, Math.max(0, remaining)); remaining -= cappedCctvs.length;
+        const cappedWorld = favoriteWorldCams.slice(0, Math.max(0, remaining));
+        html += cappedBookmarks.map(item => renderSearchItem(item, true)).join('');
         html += cappedCctvs.map(cctv => renderCctvFavoriteSearchItem(cctv)).join('');
         html += cappedWorld.map(cam => renderWorldTourFavoriteSearchItem(cam)).join('');
+    } else {
+        html += '<div class="search-section-empty">아직 즐겨찾기한 항목이 없습니다 — 검색 결과의 별 아이콘을 눌러 추가하세요.</div>';
     }
 
-    // Bookmarks Section (always show)
-    html += `<div class="search-section-title">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M5 5c0-1.1.9-2 2-2h10a2 2 0 0 1 2 2v16l-7-3.5L5 21V5z"/></svg>
-        북마크
-    </div>`;
-    if (bookmarks.length > 0) {
-        html += bookmarks.map(item => renderSearchItem(item, true)).join('');
-    } else {
-        html += '<div class="search-section-empty">최근 북마크된 주소가 없습니다</div>';
-    }
 
     // History Section (always show)
     html += `<div class="search-section-title">최근 검색</div>`;
@@ -1031,9 +1027,9 @@ function renderSearchItem(item, isBookmarked) {
                 <div class="search-result-address">${item.address || ''}</div>
             </div>
             <div class="search-result-actions">
-                <button class="btn-bookmark ${bookmarkClass}" data-action="bookmark" title="북마크">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="${isBookmarked ? 'currentColor' : 'none'}" stroke="currentColor" stroke-width="2">
-                        <path d="M5 5c0-1.1.9-2 2-2h10a2 2 0 0 1 2 2v16l-7-3.5L5 21V5z"/>
+                <button class="btn-bookmark ${bookmarkClass}" data-action="bookmark" title="${isBookmarked ? '즐겨찾기 해제' : '즐겨찾기 추가'}" aria-pressed="${isBookmarked}" aria-label="${isBookmarked ? '즐겨찾기 해제' : '즐겨찾기 추가'}">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="${isBookmarked ? 'currentColor' : 'none'}" stroke="currentColor" stroke-width="2" stroke-linejoin="round">
+                        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/>
                     </svg>
                 </button>
                 <button class="btn-delete" data-action="delete" title="삭제">
@@ -2620,14 +2616,11 @@ function renderSelectTrigger(panel, cctv, fallbackLabel) {
     const sourceMeta = getSourceMeta(cctv);
     trigger.innerHTML = '';
 
-    // Small colored dot identifies the source (SPATIC, UTIC, NTIC, ...)
-    if (cctv) {
-        const sourceDot = document.createElement('span');
-        sourceDot.className = 'cctv-source-dot';
-        sourceDot.style.background = sourceMeta.color;
-        sourceDot.setAttribute('aria-hidden', 'true');
-        trigger.append(sourceDot);
-    }
+    // The data-source dot (SPATIC / UTIC / NTIC) used to sit on the LEFT
+    // of the name, paired with the playback-status dot on the right.
+    // That made the trigger feel double-decorated. We keep only the
+    // status dot (right) which conveys playback health — the more useful
+    // signal — and surface the source label through the tooltip.
 
     const name = document.createElement('span');
     name.className = 'cctv-select-name';
@@ -4685,6 +4678,12 @@ function initMap() {
     };
 
     map = new kakao.maps.Map(container, options);
+    // Cap the zoom-out so users don't end up looking at the empty
+    // beige "kakaomap" background. Kakao's outer levels (>= 12) often
+    // have no tiles for South Korea, leaving the map blank.
+    if (typeof map.setMaxLevel === 'function') {
+        map.setMaxLevel(11);
+    }
     state.mapInitialized = true;
 
     // Map Move Event handler
@@ -5537,8 +5536,14 @@ function renderWorldTourFavoriteButton(cam, variant = 'card') {
 }
 
 function getWorldTourRegionCounts(cams) {
+    // Honor the "원본만 보기" toggle — when active, region chip counts
+    // (All / North America / Europe / ...) drop to the playable-only set
+    // so the count matches the map markers and card rail.
+    const source = state.worldTourListExcludeExternal
+        ? cams.filter(canPlayWorldTourInApp)
+        : cams;
     const favorites = getWorldTourFavoriteIds();
-    return cams.reduce((counts, cam) => {
+    return source.reduce((counts, cam) => {
         const region = cam.region || 'Other';
         counts.All = (counts.All || 0) + 1;
         if (favorites.has(String(cam.id))) {


### PR DESCRIPTION
## 사용자 요청 두 가지

### 1) 북마크 → 즐겨찾기 통합 (별 아이콘)
- 검색 드롭다운에서 "북마크" 별도 섹션 제거. **"즐겨찾기 · Favorite"** 한 섹션 안에 세 종류를 순서대로:
  1. 장소 즐겨찾기 (예전 북마크 — 천왕역모아엘가/제이헤어/크라운모텔 같은 주소)
  2. 도메스틱 CCTV 즐겨찾기
  3. World Tour 카메라 즐겨찾기
- 책갈피 SVG (`<path d="M5 5c0...">`) → 5-point 별 polygon (다른 곳과 동일한 아이콘) 으로 교체.
- 토글 title/aria 라벨 "즐겨찾기 추가" / "즐겨찾기 해제" 일관화.
- 빈 상태 카피: "아직 즐겨찾기한 항목이 없습니다 — 검색 결과의 별 아이콘을 눌러 추가하세요."
- 백엔드 식별자 (`toggleBookmark`, `getBookmarks`, localStorage `cctv_bookmarks`)는 의도적으로 그대로 둠 — UI 표면만 리브랜딩, 저장 마이그레이션 노이즈 회피.

### 2) 원본만 보기 토글을 지역 칩 카운트에 동기화
- `getWorldTourRegionCounts(cams)`가 `state.worldTourListExcludeExternal=true`일 때 `cams.filter(canPlayWorldTourInApp)`로 사전 필터링.
- 지도 마커와 하단 card rail은 이미 `getWorldTourVisibleCams`를 통해 토글을 인식하고 있었지만, 하단 메뉴 상단의 지역 칩 (`All / North America / Europe / ...`)이 여전히 1515를 표시.
- 이제 토글이 켜지면 칩 카운트도 924 기반으로 줄어들어 지도/카드와 정확히 동기화.

### 검증
- `node --check js/app.js` 통과
- 1 file / +40 / -35