### PR TITLE
fix(favorites): World Tour 즐겨찾기 클릭 시 영상 열기 (PR6)

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <link rel="dns-prefetch" href="//dapi.kakao.com">
     <link rel="dns-prefetch" href="//tile.openstreetmap.org">
-    <link rel="stylesheet" href="css/style.css?v=20260521-25213e30">
+    <link rel="stylesheet" href="css/style.css?v=20260521-pr6-fav-click-fix">
 
     <!-- Kakao Maps -->
     <script type="text/javascript"
@@ -253,7 +253,7 @@
             summaryUrl: 'https://cctv-quality.pyw31337.workers.dev/v1/summary'
         };
     </script>
-    <script src="js/app.js?v=20260521-25213e30"></script>
+    <script src="js/app.js?v=20260521-pr6-fav-click-fix"></script>
     <script>
         // Register the offline-friendly service worker. Wrapped in a load
         // listener so SW registration never blocks first paint; wrapped in a

--- a/js/app.js
+++ b/js/app.js
@@ -18,7 +18,7 @@ const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-25213e30';
+const APP_BUILD_VERSION = '20260521-pr6-fav-click-fix';
 const QUALITY_CONFIG = window.CCTV_QUALITY_CONFIG || {};
 const QUALITY_TELEMETRY_ENDPOINT = QUALITY_CONFIG.telemetryEndpoint || 'https://cctv-quality.pyw31337.workers.dev/v1/events';
 const QUALITY_SUMMARY_URL = QUALITY_CONFIG.summaryUrl || 'https://cctv-quality.pyw31337.workers.dev/v1/summary';
@@ -757,11 +757,18 @@ function setupEventListeners() {
                 const id = favItem.dataset.worldCamId;
                 $('#search-results').classList.remove('active');
                 $('#dim-overlay').classList.remove('active');
-                if (id) {
-                    state.selectedWorldTourId = id;
-                    state.worldTourRegion = 'All';
-                    if (typeof openWeather === 'function') openWeather('world-tour');
-                    else if (typeof renderWorldTourCams === 'function') renderWorldTourCams(id, { viewMode: state.worldTourViewMode || 'video' });
+                if (!id) return;
+                state.selectedWorldTourId = id;
+                state.worldTourRegion = 'All';
+                state.worldTourViewMode = 'video';
+                if (typeof openWorldTourPanel === 'function') {
+                    Promise.resolve(openWorldTourPanel()).then(() => {
+                        if (typeof renderWorldTourCams === 'function') {
+                            renderWorldTourCams(id, { viewMode: 'video' });
+                        }
+                    }).catch(err => console.warn('[favorites] world tour open failed:', err));
+                } else if (typeof renderWorldTourCams === 'function') {
+                    renderWorldTourCams(id, { viewMode: 'video' });
                 }
                 return;
             }

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@
 // The CACHE_VERSION is hot-swapped by the deploy GHA so a new release purges
 // all prior caches even when a long-lived tab still holds the old SW.
 
-const CACHE_VERSION = 'v20260521-25213e30';
+const CACHE_VERSION = 'v20260521-pr6-fav-click-fix';
 
 const SHELL_ASSETS = [
     './',


### PR DESCRIPTION
### 버그
즐겨찾기 통합 섹션에서 경복궁/광안대교/남산타워(World Tour 즐겨찾기) 항목을 클릭해도 아무 반응이 없었습니다.

### 원인
`openWeather("world-tour")` 호출 — 그런 함수가 없음. 실제 entry는 `openWorldTourPanel()` 입니다.

### Fix
- `openWorldTourPanel()` 호출 → shell mount + cams 로드
- 그 후 `renderWorldTourCams(id, { viewMode: "video" })` 체이닝 → 영상 모드로 즉시 진입

### 첫번째 스크린샷의 "북마크" 별도 노출에 대해
코드상으로는 PR #75에서 이미 한 섹션으로 통합되어 main에 머지되어 있습니다 ([raw 확인](https://raw.githubusercontent.com/pyw31337/cctv/main/js/app.js)). 화면에 두 섹션이 보이는 건 **Service Worker가 옛 shell을 캐시 중**이어서 입니다. 이번 PR로 `CACHE_VERSION`이 `pr6-fav-click-fix`로 bump되어 다음 방문에 자동 무효화 됩니다. 즉시 보고 싶으시면 Cmd+Shift+R (강력 새로고침) 한 번이면 됩니다.