### PR TITLE
fix(world-tour): keep map draggable while right list panel is open (PR7)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2155,6 +2155,14 @@ body.world-tour-active #pwa-install-prompt {
     background: transparent;
     backdrop-filter: none;
     -webkit-backdrop-filter: none;
+    /* Let clicks / drags pass through to the underlying map and bottom
+     * menu so the left side stays fully interactive. The panel inside
+     * reclaims pointer events below. */
+    pointer-events: none;
+}
+
+.world-tour-list-overlay.is-searching .world-tour-list-panel {
+    pointer-events: auto;
 }
 
 .world-tour-shell.is-searching .world-tour-bottom-menu {

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <link rel="dns-prefetch" href="//dapi.kakao.com">
     <link rel="dns-prefetch" href="//tile.openstreetmap.org">
-    <link rel="stylesheet" href="css/style.css?v=20260521-74ba5adc">
+    <link rel="stylesheet" href="css/style.css?v=20260521-pr7-passthrough">
 
     <!-- Kakao Maps -->
     <script type="text/javascript"
@@ -253,7 +253,7 @@
             summaryUrl: 'https://cctv-quality.pyw31337.workers.dev/v1/summary'
         };
     </script>
-    <script src="js/app.js?v=20260521-74ba5adc"></script>
+    <script src="js/app.js?v=20260521-pr7-passthrough"></script>
     <script>
         // Register the offline-friendly service worker. Wrapped in a load
         // listener so SW registration never blocks first paint; wrapped in a

--- a/js/app.js
+++ b/js/app.js
@@ -18,7 +18,7 @@ const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-74ba5adc';
+const APP_BUILD_VERSION = '20260521-pr7-passthrough';
 const QUALITY_CONFIG = window.CCTV_QUALITY_CONFIG || {};
 const QUALITY_TELEMETRY_ENDPOINT = QUALITY_CONFIG.telemetryEndpoint || 'https://cctv-quality.pyw31337.workers.dev/v1/events';
 const QUALITY_SUMMARY_URL = QUALITY_CONFIG.summaryUrl || 'https://cctv-quality.pyw31337.workers.dev/v1/summary';
@@ -6319,11 +6319,13 @@ function bindWorldTourListPanel(root, cams, selected) {
         });
     };
 
-    overlay.addEventListener('click', event => {
-        if (event.target !== overlay) return;
-        state.worldTourListOpen = false;
-        rerenderWithList();
-    });
+    // Intentionally NOT closing the panel on overlay click — the overlay
+    // covers the entire viewport, and the user wants the left side (map +
+    // markers + card rail) to stay fully interactive while the right
+    // panel is open. To dismiss the panel use the × close button in the
+    // panel header (or the list-toggle button in the bottom menu).
+    // Pointer-events: none on the overlay (set in CSS for is-searching)
+    // means clicks pass through to the underlying map / cards anyway.
 
     const searchInput = panel.querySelector('[data-world-tour-list-search]');
     searchInput?.addEventListener('input', event => {

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@
 // The CACHE_VERSION is hot-swapped by the deploy GHA so a new release purges
 // all prior caches even when a long-lived tab still holds the old SW.
 
-const CACHE_VERSION = 'v20260521-74ba5adc';
+const CACHE_VERSION = 'v20260521-pr7-passthrough';
 
 const SHELL_ASSETS = [
     './',


### PR DESCRIPTION
### 버그
우측 리스트 패널이 열려 있을 때 좌측 지도가 드래그되지 않고, 좌측을 클릭하면 우측 패널이 닫히면서 하단 메뉴가 다시 등장.

### 원인
`.world-tour-list-overlay`가 `position: fixed; inset: 0`으로 전체 뷰포트를 덮고 있어, 좌측 어느 곳을 클릭/드래그해도 overlay가 가로채서:
- `overlay.click` 핸들러가 `state.worldTourListOpen = false`로 패널 닫음
- 재렌더 시 `is-searching` 클래스 빠지면서 bottom menu 재등장

### Fix
1. **CSS**: `.world-tour-list-overlay.is-searching`에 `pointer-events: none` → 클릭/드래그가 아래 지도로 통과. 패널 자신은 `pointer-events: auto`로 살림.
2. **JS**: `overlay.addEventListener("click", close)` 제거 — 명시적 × 버튼이나 bottom menu의 리스트 토글로만 닫힘.

### 결과
- 좌측 지도 자유롭게 pan/zoom
- 마커 클릭으로 cam 전환 가능
- 우측 패널은 그대로 유지
- 하단 메뉴 등장 안 함

빌드 버전 `20260521-pr7-passthrough` + SW CACHE_VERSION 동기 bump.