### PR TITLE
fix(world-tour): keep list panel open + center hero in left gutter (PR8)

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -4124,3 +4124,21 @@ body.world-tour-active #pwa-install-prompt {
 .cctv-favorite-item--world .source-dot {
     background: linear-gradient(135deg, #34d399, #38bdf8);
 }
+
+/* PR8 panel-aware hero gutter: while the right list panel is open the
+ * world-tour shell carries .is-searching. Push the hero (map or video)
+ * away from the right edge by the panel width so the visible left area
+ * shows the content centered, not hidden under the 430px panel. */
+@media (min-width: 720px) {
+    .world-tour-shell.is-searching .world-tour-hero {
+        right: min(430px, 100vw);
+    }
+    .world-tour-shell.is-searching .world-tour-map-stage {
+        right: min(430px, 100vw);
+    }
+    .world-tour-shell.is-searching .world-tour-video {
+        margin-left: auto;
+        margin-right: auto;
+        max-width: 100%;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <link rel="dns-prefetch" href="//dapi.kakao.com">
     <link rel="dns-prefetch" href="//tile.openstreetmap.org">
-    <link rel="stylesheet" href="css/style.css?v=20260521-380bf3e8">
+    <link rel="stylesheet" href="css/style.css?v=20260521-pr8-split-view">
 
     <!-- Kakao Maps -->
     <script type="text/javascript"
@@ -253,7 +253,7 @@
             summaryUrl: 'https://cctv-quality.pyw31337.workers.dev/v1/summary'
         };
     </script>
-    <script src="js/app.js?v=20260521-380bf3e8"></script>
+    <script src="js/app.js?v=20260521-pr8-split-view"></script>
     <script>
         // Register the offline-friendly service worker. Wrapped in a load
         // listener so SW registration never blocks first paint; wrapped in a

--- a/js/app.js
+++ b/js/app.js
@@ -18,7 +18,7 @@ const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-380bf3e8';
+const APP_BUILD_VERSION = '20260521-pr8-split-view';
 const QUALITY_CONFIG = window.CCTV_QUALITY_CONFIG || {};
 const QUALITY_TELEMETRY_ENDPOINT = QUALITY_CONFIG.telemetryEndpoint || 'https://cctv-quality.pyw31337.workers.dev/v1/events';
 const QUALITY_SUMMARY_URL = QUALITY_CONFIG.summaryUrl || 'https://cctv-quality.pyw31337.workers.dev/v1/summary';
@@ -6387,21 +6387,18 @@ function bindWorldTourListPanel(root, cams, selected) {
 
         const videoButton = event.target.closest('[data-world-tour-list-video]');
         if (videoButton) {
-            state.worldTourListOpen = false;
             renderWorldTourCams(videoButton.dataset.worldTourListVideo, { viewMode: 'video' });
             return;
         }
 
         const mapButton = event.target.closest('[data-world-tour-list-map]');
         if (mapButton) {
-            state.worldTourListOpen = false;
             renderWorldTourCams(mapButton.dataset.worldTourListMap, { viewMode: 'map' });
             return;
         }
 
         const item = event.target.closest('[data-world-tour-list-item]');
         if (item) {
-            state.worldTourListOpen = false;
             renderWorldTourCams(item.dataset.worldTourListItem, { viewMode: state.worldTourViewMode });
         }
     });
@@ -6411,7 +6408,6 @@ function bindWorldTourListPanel(root, cams, selected) {
         const item = event.target.closest('[data-world-tour-list-item]');
         if (!item) return;
         event.preventDefault();
-        state.worldTourListOpen = false;
         renderWorldTourCams(item.dataset.worldTourListItem, { viewMode: state.worldTourViewMode });
     });
 }

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@
 // The CACHE_VERSION is hot-swapped by the deploy GHA so a new release purges
 // all prior caches even when a long-lived tab still holds the old SW.
 
-const CACHE_VERSION = 'v20260521-380bf3e8';
+const CACHE_VERSION = 'v20260521-pr8-split-view';
 
 const SHELL_ASSETS = [
     './',


### PR DESCRIPTION
### 사용자 요청
우측 패널이 열린 상태에서 "경복궁" / "광안대교" 같은 항목 또는 "영상" 버튼을 누르면:
- 우측 패널이 닫히지 않고 유지
- 좌측 영역에서만 영상이 바뀌어 표시
- 영상은 좌측 영역의 좌우 중앙에 위치

### Fix
- `bindWorldTourListPanel` 의 4개 in-panel 핸들러 (video btn / map btn / item click / keydown) 에서 `state.worldTourListOpen = false` 제거. 재렌더는 그대로 실행되어 hero(좌측)만 갱신됨.
- CSS `@media (min-width: 720px)`: `.world-tour-shell.is-searching` 의 `.world-tour-hero` 와 `.world-tour-map-stage` 에 `right: min(430px, 100vw)` 추가. 우측 패널(430px) 너비만큼 hero 가 안쪽으로 들어와 좌측 영역에서 자연스럽게 중앙 정렬됨.
- 비디오는 `margin: auto + max-width: 100%` 로 좌측 영역 내부 중앙.

### 결과
사이드 바이 사이드 비교 뷰: 우측에서 다른 도시 클릭 → 좌측 영상만 전환, 우측 패널 그대로 유지.

빌드 버전 `20260521-pr8-split-view`.