### PR TITLE
fix(favorites): lazy-load World Tour cams so 경복궁/광안대교/남산타워 appear in 즐겨찾기 (PR9 v2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <link rel="dns-prefetch" href="//dapi.kakao.com">
     <link rel="dns-prefetch" href="//tile.openstreetmap.org">
-    <link rel="stylesheet" href="css/style.css?v=20260521-d2509965">
+    <link rel="stylesheet" href="css/style.css?v=20260521-pr9-fav-lazyload">
 
     <!-- Kakao Maps -->
     <script type="text/javascript"
@@ -253,7 +253,7 @@
             summaryUrl: 'https://cctv-quality.pyw31337.workers.dev/v1/summary'
         };
     </script>
-    <script src="js/app.js?v=20260521-d2509965"></script>
+    <script src="js/app.js?v=20260521-pr9-fav-lazyload"></script>
     <script>
         // Register the offline-friendly service worker. Wrapped in a load
         // listener so SW registration never blocks first paint; wrapped in a

--- a/js/app.js
+++ b/js/app.js
@@ -18,7 +18,7 @@ const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-d2509965';
+const APP_BUILD_VERSION = '20260521-pr9-fav-lazyload';
 const QUALITY_CONFIG = window.CCTV_QUALITY_CONFIG || {};
 const QUALITY_TELEMETRY_ENDPOINT = QUALITY_CONFIG.telemetryEndpoint || 'https://cctv-quality.pyw31337.workers.dev/v1/events';
 const QUALITY_SUMMARY_URL = QUALITY_CONFIG.summaryUrl || 'https://cctv-quality.pyw31337.workers.dev/v1/summary';
@@ -917,6 +917,27 @@ function renderSearchSortPanel() {
 function showSearchHistory() {
     // Close weather popup when opening search
     closeWeather();
+
+    // Lazy-load World Tour cams the first time the search panel opens so
+    // World Tour favorites (경복궁/광안대교/남산타워 등) appear in the
+    // unified 즐겨찾기 섹션 even before the user has opened the world
+    // tour view. Fire-and-forget; re-render when ready.
+    try {
+        const favIds = getUnifiedFavoriteIds();
+        const camsLoaded = Array.isArray(state.worldTourCams)
+            || Array.isArray(state.worldTourCams?.items);
+        if (favIds && favIds.size && !camsLoaded && typeof loadWorldTourCams === 'function') {
+            loadWorldTourCams()
+                .then(() => {
+                    const resultsEl = document.getElementById('search-results');
+                    if (resultsEl && resultsEl.classList.contains('active')) {
+                        showSearchHistory();
+                    }
+                })
+                .catch(err => console.warn('[favorites] world tour cams lazy-load failed:', err));
+        }
+    } catch (_) { /* defensive */ }
+
 
     const resultsEl = $('#search-results');
     const compactPanel = shouldUseCompactSearchPanel();

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@
 // The CACHE_VERSION is hot-swapped by the deploy GHA so a new release purges
 // all prior caches even when a long-lived tab still holds the old SW.
 
-const CACHE_VERSION = 'v20260521-d2509965';
+const CACHE_VERSION = 'v20260521-pr9-fav-lazyload';
 
 const SHELL_ASSETS = [
     './',


### PR DESCRIPTION
### 버그
도메스틱 카카오맵 검색 패널의 즐겨찾기 섹션에 장소 북마크만 보이고 World Tour 즐겨찾기(경복궁/광안대교/남산타워)가 누락. 카운트 (4).

### 원인
`getFavoriteWorldTourCams()`가 `state.worldTourCams`를 참조하는데 그 데이터는 World Tour 패널을 처음 열어야 로드됨. 도메스틱 화면에서 검색 패널 먼저 열면 `null` 상태 → 매칭 실패.

### Fix
`showSearchHistory()` 진입 시 통합 favorite id가 있고 cams 미로드면 `loadWorldTourCams()` fire-and-forget. 로드 완료 후 검색 패널이 여전히 active면 `showSearchHistory()` 재호출 → 누락된 World Tour 즐겨찾기 등장.

빌드 버전 `20260521-pr9-fav-lazyload`.