### PR TITLE
feat(gits): daily GITS ingest workflow

### DIFF
--- a/.github/workflows/gits_repair.yml
+++ b/.github/workflows/gits_repair.yml
@@ -1,44 +1,42 @@
-name: GITS Stream Repair
+name: GITS Daily Ingest
+
+# GITS 카메라 (경기도) 1,800+개의 popup token 은 단기 만료성이라 daily fresh ingest 필요.
+# 이전엔 cctv-proxy worker /gits 가 실시간 fetch 했으나 Oracle /gits 가 hang 하면서 망가짐.
+# popup 자체는 살아있어서 collectors.gits.GitsCollector 로 직접 긁어 cctv_data.json 에 넣는다.
 
 on:
-  # Disabled: GITS tokens now fetched in real-time via CF Worker /gits endpoint
-  # schedule:
-  #   - cron: '0 */2 * * *'
+  schedule:
+    # 매일 새벽 4시 KST (= 19:00 UTC 전날)
+    - cron: '0 19 * * *'
   workflow_dispatch:
 
 permissions:
   contents: write
 
-jobs:
-  repair-gits:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+concurrency:
+  group: gits-daily-ingest
+  cancel-in-progress: true
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+jobs:
+  ingest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install requests
+        run: pip install requests urllib3
 
-      - name: Run GITS Repair
-        run: python scripts/repair_gits_streams.py
+      - name: Run GITS ingest
+        run: python scripts/ingest_gits.py
 
-      - name: Commit and push changes
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          # Check if cctv_data.json was modified
-          if [[ -n $(git status -s cctv_data.json) ]]; then
-            git add cctv_data.json
-            git commit -m "chore: auto-repair GITS streams"
-            git pull --rebase origin main
-            git push
-          else
-            echo "No repairs needed."
-          fi
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: "chore: daily GITS ingest"
+          file_pattern: "cctv_data.json"
+          branch: main

--- a/scripts/ingest_gits.py
+++ b/scripts/ingest_gits.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+GITS 카메라 (경기도 지능형 교통체계) 1,800+개를 cctv_data.json 에 ingest.
+
+배경:
+  - 이전엔 cctv-proxy worker /gits 엔드포인트가 실시간으로 popup → video URL 추출했으나
+    현재 Oracle /gits 가 hang/응답 없음. 클라이언트 재생 경로가 전부 막힘.
+  - GITS popup 자체는 살아있고 `<video src="https://gitsview.gg.go.kr/{id}/{token}">` 패턴으로
+    유효한 mp4/m3u8 토큰을 반환함이 확인됨 (테스트 일자: 2026-05-21).
+  - 따라서 popup 을 daily 로 한 번씩 긁어 fresh URL 을 cctv_data.json 에 박는 전략으로 전환.
+
+전략:
+  - collectors.gits.GitsCollector 를 그대로 사용 (이미 popup 3개 패턴 처리)
+  - 기존 source=GITS 항목 전부 제거 후 새 항목 추가 (Upsert)
+  - 결과: 클라이언트는 별도 worker 없이 cctv.url 을 video src 로 직접 사용 가능
+"""
+import json
+import os
+import sys
+import time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+from collectors.gits import GitsCollector
+
+CCTV_DATA = os.path.join(ROOT, "cctv_data.json")
+
+
+def main():
+    print("[gits-ingest] starting GitsCollector...", flush=True)
+    t0 = time.time()
+    collector = GitsCollector()
+    fresh = collector.fetch_data()
+    print(
+        f"[gits-ingest] collector returned {len(fresh)} cameras "
+        f"in {time.time()-t0:.0f}s",
+        flush=True,
+    )
+
+    if not fresh:
+        print("[gits-ingest] empty result - aborting to avoid wiping cctv_data.json", flush=True)
+        sys.exit(1)
+
+    now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    for cam in fresh:
+        cam.setdefault("source", "GITS")
+        cam.setdefault("status", "active")
+        cam.setdefault("backup_urls", [])
+        cam["ingested_at"] = now_iso
+
+    with open(CCTV_DATA, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    before_gits = sum(1 for c in data if c.get("source") == "GITS")
+    others = [c for c in data if c.get("source") != "GITS"]
+    merged = others + fresh
+    print(
+        f"[gits-ingest] cctv_data.json: GITS {before_gits} -> {len(fresh)}, "
+        f"total {len(data)} -> {len(merged)}",
+        flush=True,
+    )
+
+    with open(CCTV_DATA, "w", encoding="utf-8") as f:
+        json.dump(merged, f, ensure_ascii=False, indent=2)
+    print(f"[gits-ingest] wrote {CCTV_DATA}", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 문제
GITS 1,816개 카메라가 cctv_data.json 에 통합 안 되어 클라이언트에서 검색·재생 불가. 이전엔 cctv-proxy worker /gits 가 실시간 popup 추출했으나 Oracle /gits 가 hang 하면서 망가짐.

진단:
- gits.gg.go.kr popup 응답 정상 (200)
- video src 패턴 살아있음 (https://gitsview.gg.go.kr/{id}/{token})
- 추출 URL 직접 호출시 200 video/mp4 (71KB~412KB) 확인
- 토큰은 사용 후 만료될 수 있어 daily 갱신 필요

## 수정
1. scripts/ingest_gits.py 신규 - GitsCollector 호출 후 cctv_data.json 의 GITS 항목 upsert. 안전장치로 빈 결과면 abort.
2. .github/workflows/gits_repair.yml 활성화 - daily cron 매일 새벽 4 KST + workflow_dispatch.

## 효과
Merge 후 workflow_dispatch 즉시 1회 trigger 하면 cctv_data.json 에 1,800+개 경기도 GITS 카메라가 추가됨.