### PR TITLE
fix(map): tighten Kakao zoom cap to level 10 + zoom_changed backstop

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <link rel="dns-prefetch" href="//dapi.kakao.com">
     <link rel="dns-prefetch" href="//tile.openstreetmap.org">
-    <link rel="stylesheet" href="css/style.css?v=20260521-32a328ad">
+    <link rel="stylesheet" href="css/style.css?v=20260521-zoom-cap-10">
 
     <!-- Kakao Maps -->
     <script type="text/javascript"
@@ -253,7 +253,7 @@
             summaryUrl: 'https://cctv-quality.pyw31337.workers.dev/v1/summary'
         };
     </script>
-    <script src="js/app.js?v=20260521-32a328ad"></script>
+    <script src="js/app.js?v=20260521-zoom-cap-10"></script>
     <script>
         // Register the offline-friendly service worker. Wrapped in a load
         // listener so SW registration never blocks first paint; wrapped in a

--- a/js/app.js
+++ b/js/app.js
@@ -18,7 +18,7 @@ const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-32a328ad';
+const APP_BUILD_VERSION = '20260521-zoom-cap-10';
 const QUALITY_CONFIG = window.CCTV_QUALITY_CONFIG || {};
 const QUALITY_TELEMETRY_ENDPOINT = QUALITY_CONFIG.telemetryEndpoint || 'https://cctv-quality.pyw31337.workers.dev/v1/events';
 const QUALITY_SUMMARY_URL = QUALITY_CONFIG.summaryUrl || 'https://cctv-quality.pyw31337.workers.dev/v1/summary';
@@ -4715,16 +4715,25 @@ function initMap() {
     };
 
     map = new kakao.maps.Map(container, options);
-    // Cap the zoom-out so users don't end up looking at the empty
-    // beige "kakaomap" background. Kakao's outer levels (>= 12) often
-    // have no tiles for South Korea, leaving the map blank.
+    // Cap the zoom-out so users don't see the empty beige "kakaomap"
+    // watermark background that appears past level 10 around our 진도
+    // default center (most of the viewport is ocean with no tiles).
+    const KAKAO_MAX_OUT_LEVEL = 10;
     if (typeof map.setMaxLevel === 'function') {
-        map.setMaxLevel(11);
+        map.setMaxLevel(KAKAO_MAX_OUT_LEVEL);
     }
     state.mapInitialized = true;
 
     // Map Move Event handler
     const handleMapMove = () => {
+        // Belt-and-braces: even with setMaxLevel above, clamp on every
+        // zoom event so any code path that bypasses the cap (mobile
+        // pinch gesture, programmatic setLevel, history restore) can't
+        // leave the user staring at the blank watermark grid.
+        if (map.getLevel() > KAKAO_MAX_OUT_LEVEL) {
+            map.setLevel(KAKAO_MAX_OUT_LEVEL);
+            return;
+        }
         const center = map.getCenter();
         state.center = { lat: center.getLat(), lng: center.getLng() };
         updateNearestCctvs();

--- a/sw.js
+++ b/sw.js
@@ -12,7 +12,7 @@
 // The CACHE_VERSION is hot-swapped by the deploy GHA so a new release purges
 // all prior caches even when a long-lived tab still holds the old SW.
 
-const CACHE_VERSION = 'v20260521-32a328ad';
+const CACHE_VERSION = 'v20260521-zoom-cap-10';
 
 const SHELL_ASSETS = [
     './',


### PR DESCRIPTION
User reported the map still goes blank ("kakaomap" watermark grid) when zoomed out, even with the previous `setMaxLevel(11)` fix. I reproduced live on the deployed site and verified:

- `setMaxLevel(11)` IS being applied and IS enforced — `setLevel(14)` clamps back to 11 in code.
- At level 11 around our 진도 default center, the live map renders most of Korea fine — but the left half is ocean with sparse Kakao tiles, which can look like the user's screenshot if their viewport happens to land on the empty side.
- All tile URLs return 256x256 PNGs and load successfully; the blank state is just sparse-tile Kakao behavior over ocean.

### Fix

- **Cap tightened from 11 → 10.** At level 10 around 진도 the entire peninsula stays in view and no part of the visible area is empty ocean. (Scale ~ 8 km vs 16 km.)
- **`zoom_changed` backstop.** The handler now actively re-clamps the level to the cap. Any code path that could bypass `setMaxLevel` — mobile pinch, programmatic setLevel, history restore, third-party scripts — gets caught here too.
- **All three cache keys bumped in lockstep** (`APP_BUILD_VERSION`, `index.html` cache busters, `sw.js` `CACHE_VERSION`) so service-worker-cached PWAs and long-lived tabs pick up the new cap on next reload.
