### PR TITLE
fix(map): restore PLAYBACK_HEALTH_* constants — real cause of blank Kakao map

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -18,7 +18,19 @@ const CCTV_DATA_BUCKET_MS = 30 * 60 * 1000;
 const HEALTH_STATUS_BUCKET_MS = 5 * 60 * 1000;
 const HEALTH_STALE_MS = 2 * 60 * 60 * 1000;
 const CAMERA_FAILURE_RECENT_MS = 3 * 60 * 60 * 1000;
-const APP_BUILD_VERSION = '20260521-9091ee75';
+const APP_BUILD_VERSION = '20260521-fix-health-ttl';
+// These constants were lost in a recent rebase and broke the map: every
+// zoom_changed event called updateNearestCctvs → getCameraHealthMeta →
+// getStoredPlaybackHealthTtl which referenced PLAYBACK_HEALTH_PROBLEM_TTL_MS
+// throwing a ReferenceError. Once the listener throws, Kakao's internal
+// tile-rendering pipeline never gets to redraw → blank map with only the
+// kakaomap watermark visible.
+const SERVICE_BANNER_VISIBLE_MS = 5000;
+const PLAYBACK_HEALTH_STORAGE_KEY = 'cctv_playback_health_v1';
+const PLAYBACK_HEALTH_SCHEMA_VERSION = 2;
+const PLAYBACK_HEALTH_OK_TTL_MS = 15 * 60 * 1000;
+const PLAYBACK_HEALTH_PROBLEM_TTL_MS = 45 * 60 * 1000;
+const PLAYBACK_HEALTH_MAX_ENTRIES = 160;
 const QUALITY_CONFIG = window.CCTV_QUALITY_CONFIG || {};
 const QUALITY_TELEMETRY_ENDPOINT = QUALITY_CONFIG.telemetryEndpoint || 'https://cctv-quality.pyw31337.workers.dev/v1/events';
 const QUALITY_SUMMARY_URL = QUALITY_CONFIG.summaryUrl || 'https://cctv-quality.pyw31337.workers.dev/v1/summary';


### PR DESCRIPTION
## Real root cause of the blank-map issue

Live debugging in Chrome on the deployed site surfaced this in the console after any map zoom or drag:

```
ReferenceError: PLAYBACK_HEALTH_PROBLEM_TTL_MS is not defined
  at getStoredPlaybackHealthTtl (js/app.js:1786)
  at isStoredPlaybackHealthFresh (js/app.js:1793)
  at getCameraHealthMeta (js/app.js:1886)
  at updateNearestCctvs (js/app.js:3183)
  at handleMapMove (js/app.js:4739)
  at kakao.js  (zoom_changed listener)
```

Five `PLAYBACK_HEALTH_*` constants (originally added by commit `55a2aab`) were dropped during a recent rebase. Every time the user moves or zooms the map, Kakao fires `zoom_changed`/`dragend`, which calls `handleMapMove`, which throws — and once the listener throws inside Kakao's internal event dispatch loop, the map's tile pipeline never gets to complete the re-paint. The result is the screenshot the user keeps sending: empty beige with `kakaomap` watermarks, only the marker overlay visible.

**This is the actual cause of "지도 안 나옴"**, not the zoom cap. `setMaxLevel(10)` was working correctly; the throw just made it look like tiles never loaded.

## Fix

Restore the dropped constants near `APP_BUILD_VERSION`:

```js
const SERVICE_BANNER_VISIBLE_MS = 5000;
const PLAYBACK_HEALTH_STORAGE_KEY = 'cctv_playback_health_v1';
const PLAYBACK_HEALTH_SCHEMA_VERSION = 2;
const PLAYBACK_HEALTH_OK_TTL_MS = 15 * 60 * 1000;
const PLAYBACK_HEALTH_PROBLEM_TTL_MS = 45 * 60 * 1000;
const PLAYBACK_HEALTH_MAX_ENTRIES = 160;
```

Verified live on Chrome: `handleMapMove` no longer throws, tiles render at every zoom level.
