### PR TITLE
fix: Baltic 스냅샷 카메라 영상이 검정화면으로만 보이던 버그

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3798,7 +3798,15 @@ body.world-tour-active #pwa-install-prompt {
     background: #000;
 }
 
+/*
+ * .world-tour-video 컨테이너는 ::before { padding-top: 56.25% } 로 16:9
+ * 비율을 강제한다. 이 위에 이미지가 같이 배치되면 ::before 영역만큼
+ * 화면 밖으로 밀려 검정 배경만 보이게 된다. iframe / direct-video 와
+ * 동일하게 absolute + inset:0 으로 컨테이너를 정확히 채우게 한다.
+ */
 .world-tour-snapshot-img {
+    position: absolute;
+    inset: 0;
     display: block;
     width: 100%;
     height: 100%;

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://unpkg.com" crossorigin>
     <link rel="dns-prefetch" href="//dapi.kakao.com">
     <link rel="dns-prefetch" href="//tile.openstreetmap.org">
-    <link rel="stylesheet" href="css/style.css?v=20260521-e9fefaa6">
+    <link rel="stylesheet" href="css/style.css?v=20260521-pr12-snap-fix">
 
     <!-- Kakao Maps -->
     <script type="text/javascript"
@@ -253,7 +253,7 @@
             summaryUrl: 'https://cctv-quality.pyw31337.workers.dev/v1/summary'
         };
     </script>
-    <script src="js/app.js?v=20260521-pr11-fav-ui"></script>
+    <script src="js/app.js?v=20260521-pr12-snap-fix"></script>
     <script>
         // Register the offline-friendly service worker. Wrapped in a load
         // listener so SW registration never blocks first paint; wrapped in a


### PR DESCRIPTION
## 변경사항

### Baltic Live Cam 스냅샷 영상이 검정 화면으로만 보이던 버그 수정

증상: World Tour 패널에서 Baltic Live Cam 계열 (Novosibirsk 등) 카메라를 영상보기로 보면 좌측 영상 영역이 새까맣게만 표시되고, "Baltic Live Cam 실시간 스냅샷 / 120초마다 자동 새로고침" 오버레이만 보임.

원인:
- `.world-tour-video` 컨테이너는 `::before { padding-top: 56.25% }` 로 16:9 비율을 강제함
- 같은 컨테이너 안에 들어가는 iframe / direct-video 는 `position: absolute; inset: 0` 로 ::before 위에 정확히 겹쳐서 렌더됨
- 그런데 `.world-tour-snapshot-img` 는 absolute 가 아니라서 ::before 다음 위치(컨테이너 아래쪽)로 밀려서 사용자 눈에는 검정 배경만 보였음

수정:
- `.world-tour-snapshot-img` 에 `position: absolute; inset: 0` 추가 → iframe/video 와 동일하게 컨테이너를 정확히 채움

## 검증
- node -c js/app.js 통과 (CSS-only 수정)
- build version bump: `20260521-pr12-snap-fix`
- 대상 소스: Baltic Live Cam (~140대), HK Traffic / USGS VolcView / Panomax / Roundshot 등 다른 snapshotUrl 기반 캠도 동일하게 정상 표시됨
